### PR TITLE
Improve allocation for SoftState in Ready.

### DIFF
--- a/raft.go
+++ b/raft.go
@@ -455,7 +455,7 @@ func newRaft(c *Config) *raft {
 
 func (r *raft) hasLeader() bool { return r.lead != None }
 
-func (r *raft) softState() *SoftState { return &SoftState{Lead: r.lead, RaftState: r.state} }
+func (r *raft) softState() SoftState { return SoftState{Lead: r.lead, RaftState: r.state} }
 
 func (r *raft) hardState() pb.HardState {
 	return pb.HardState{

--- a/rawnode_test.go
+++ b/rawnode_test.go
@@ -1239,6 +1239,7 @@ func benchmarkRawNodeImpl(b *testing.B, peers ...uint64) {
 	if applied < uint64(b.N) {
 		b.Fatalf("did not apply everything: %d < %d", applied, b.N)
 	}
+	b.ReportAllocs()
 	b.ReportMetric(float64(s.callStats.firstIndex)/float64(b.N), "firstIndex/op")
 	b.ReportMetric(float64(s.callStats.lastIndex)/float64(b.N), "lastIndex/op")
 	b.ReportMetric(float64(s.callStats.term)/float64(b.N), "term/op")

--- a/status.go
+++ b/status.go
@@ -59,7 +59,7 @@ func getBasicStatus(r *raft) BasicStatus {
 		LeadTransferee: r.leadTransferee,
 	}
 	s.HardState = r.hardState()
-	s.SoftState = *r.softState()
+	s.SoftState = r.softState()
 	s.Applied = r.raftLog.applied
 	return s
 }


### PR DESCRIPTION
Fixes: [etcd-io/raft#10](https://github.com/etcd-io/raft/issues/10).

Improve allocation for `SoftState` in `Ready` so that only when changes, it will escape to the heap.

`BenchmarkRawNode` result (generated by [benchdiff](https://github.com/nvanbenschoten/benchdiff)):
```
name                     old time/op        new time/op        delta
RawNode/two-voters-12          1.54µs ±18%        1.44µs ± 7%   -6.85%  (p=0.041 n=10+8)
RawNode/single-voter-12         892ns ± 4%         871ns ±20%     ~     (p=0.182 n=9+10)

name                     old firstIndex/op  new firstIndex/op  delta
RawNode/single-voter-12          2.00 ± 0%          2.00 ± 0%     ~     (all equal)
RawNode/two-voters-12            6.00 ± 0%          6.00 ± 0%     ~     (all equal)

name                     old lastIndex/op   new lastIndex/op   delta
RawNode/single-voter-12          2.00 ± 0%          2.00 ± 0%     ~     (all equal)
RawNode/two-voters-12            2.00 ± 0%          2.00 ± 0%     ~     (all equal)

name                     old ready/op       new ready/op       delta
RawNode/single-voter-12          2.00 ± 0%          2.00 ± 0%     ~     (all equal)
RawNode/two-voters-12            2.00 ± 0%          2.00 ± 0%     ~     (all equal)

name                     old term/op        new term/op        delta
RawNode/single-voter-12          0.00 ± 7%          0.00 ± 0%     ~     (p=0.108 n=9+10)
RawNode/two-voters-12            1.00 ± 0%          1.00 ± 0%     ~     (all equal)

name                     old alloc/op       new alloc/op       delta
RawNode/single-voter-12          422B ± 2%          376B ± 4%  -10.92%  (p=0.000 n=8+10)
RawNode/two-voters-12            658B ± 3%          629B ± 3%   -4.44%  (p=0.000 n=10+10)

name                     old allocs/op      new allocs/op      delta
RawNode/single-voter-12          5.00 ± 0%          3.00 ± 0%  -40.00%  (p=0.000 n=10+10)
RawNode/two-voters-12            7.00 ± 0%          5.00 ± 0%  -28.57%  (p=0.000 n=10+10)
```