### PR TITLE
raft: disabling uncommitted size accounting for emptyEntry

### DIFF
--- a/raft.go
+++ b/raft.go
@@ -897,11 +897,10 @@ func (r *raft) becomeLeader() {
 		// This won't happen because we just called reset() above.
 		r.logger.Panic("empty entry was dropped")
 	}
-	// As a special case, don't count the initial empty entry towards the
-	// uncommitted log quota. This is because we want to preserve the
-	// behavior of allowing one entry larger than quota if the current
-	// usage is zero.
-	r.reduceUncommittedSize(payloadSize(emptyEnt))
+	// The payloadSize of an empty entry is 0 (see TestPayloadSizeOfEmptyEntry),
+	// so the preceding log append does not count against the uncommitted log
+	// quota of the new leader. In other words, after the call to appendEntry,
+	// r.uncommittedSize is still 0.
 	r.logger.Infof("%x became leader at term %d", r.id, r.Term)
 }
 

--- a/util_test.go
+++ b/util_test.go
@@ -139,3 +139,11 @@ func TestIsResponseMsg(t *testing.T) {
 		}
 	}
 }
+
+// TestPayloadSizeOfEmptyEntry ensures that payloadSize of empty entry is always zero.
+// This property is important because new leaders append an empty entry to their log,
+// and we don't want this to count towards the uncommitted log quota.
+func TestPayloadSizeOfEmptyEntry(t *testing.T) {
+	e := pb.Entry{Data: nil}
+	require.Equal(t, 0, int(payloadSize(e)))
+}


### PR DESCRIPTION
In becomeLeader method(raft.go) we reduce the uncommitted size for empty entry, which is basically a no-op as payload size will always be 0 for empty entries. Added a test case to check that as well.

Signed-off-by: Daman Arora <daman1807@github.com>

this closes #12 