### PR TITLE
raft: fix panic on MsgApp after log truncation

### DIFF
--- a/node_util_test.go
+++ b/node_util_test.go
@@ -60,7 +60,7 @@ func (l *nodeTestHarness) Warningf(format string, v ...interface{}) {
 
 func (l *nodeTestHarness) Fatal(v ...interface{}) {
 	l.t.Error(v...)
-	panic(v)
+	panic(fmt.Sprint(v...))
 }
 
 func (l *nodeTestHarness) Fatalf(format string, v ...interface{}) {
@@ -70,7 +70,7 @@ func (l *nodeTestHarness) Fatalf(format string, v ...interface{}) {
 
 func (l *nodeTestHarness) Panic(v ...interface{}) {
 	l.t.Log(v...)
-	panic(v)
+	panic(fmt.Sprint(v...))
 }
 
 func (l *nodeTestHarness) Panicf(format string, v ...interface{}) {

--- a/raft_test.go
+++ b/raft_test.go
@@ -2559,7 +2559,7 @@ func TestReadOnlyForNewLeader(t *testing.T) {
 	if sm.raftLog.committed != 4 {
 		t.Fatalf("committed = %d, want 4", sm.raftLog.committed)
 	}
-	lastLogTerm := sm.raftLog.zeroTermOnErrCompacted(sm.raftLog.term(sm.raftLog.committed))
+	lastLogTerm := sm.raftLog.zeroTermOnOutOfBounds(sm.raftLog.term(sm.raftLog.committed))
 	if lastLogTerm != sm.Term {
 		t.Fatalf("last log term = %d, want %d", lastLogTerm, sm.Term)
 	}

--- a/raft_test.go
+++ b/raft_test.go
@@ -2614,7 +2614,7 @@ func TestLeaderAppResp(t *testing.T) {
 		// thus the last log term must be 1 to be committed.
 		sm := newTestRaft(1, 10, 1, newTestMemoryStorage(withPeers(1, 2, 3)))
 		sm.raftLog = &raftLog{
-			storage:  &MemoryStorage{ents: []pb.Entry{{}, {Index: 1, Term: 0}, {Index: 2, Term: 1}}},
+			storage:  &MemoryStorage{ents: []pb.Entry{{}, {Index: 1, Term: 1}, {Index: 2, Term: 1}}},
 			unstable: unstable{offset: 3},
 		}
 		sm.becomeCandidate()
@@ -2722,7 +2722,7 @@ func TestRecvMsgBeat(t *testing.T) {
 
 	for i, tt := range tests {
 		sm := newTestRaft(1, 10, 1, newTestMemoryStorage(withPeers(1, 2, 3)))
-		sm.raftLog = &raftLog{storage: &MemoryStorage{ents: []pb.Entry{{}, {Index: 1, Term: 0}, {Index: 2, Term: 1}}}}
+		sm.raftLog = &raftLog{storage: &MemoryStorage{ents: []pb.Entry{{}, {Index: 1, Term: 1}, {Index: 2, Term: 1}}}}
 		sm.Term = 1
 		sm.state = tt.state
 		switch tt.state {

--- a/rafttest/interaction_env_logger.go
+++ b/rafttest/interaction_env_logger.go
@@ -82,17 +82,23 @@ func (l *RedirectLogger) Errorf(format string, v ...interface{}) {
 
 func (l *RedirectLogger) Fatal(v ...interface{}) {
 	l.print(4, v...)
+	panic(v)
 }
 
 func (l *RedirectLogger) Fatalf(format string, v ...interface{}) {
-
 	l.printf(4, format, v...)
+	panic(fmt.Sprintf(format, v...))
 }
 
 func (l *RedirectLogger) Panic(v ...interface{}) {
 	l.print(4, v...)
+	panic(v)
 }
 
 func (l *RedirectLogger) Panicf(format string, v ...interface{}) {
 	l.printf(4, format, v...)
+	// TODO(pavelkalinnikov): catch the panic gracefully in datadriven package.
+	// This would allow observing all the intermediate logging while debugging,
+	// and testing the cases when panic is expected.
+	panic(fmt.Sprintf(format, v...))
 }

--- a/rafttest/interaction_env_logger.go
+++ b/rafttest/interaction_env_logger.go
@@ -82,7 +82,7 @@ func (l *RedirectLogger) Errorf(format string, v ...interface{}) {
 
 func (l *RedirectLogger) Fatal(v ...interface{}) {
 	l.print(4, v...)
-	panic(v)
+	panic(fmt.Sprint(v...))
 }
 
 func (l *RedirectLogger) Fatalf(format string, v ...interface{}) {
@@ -92,7 +92,7 @@ func (l *RedirectLogger) Fatalf(format string, v ...interface{}) {
 
 func (l *RedirectLogger) Panic(v ...interface{}) {
 	l.print(4, v...)
-	panic(v)
+	panic(fmt.Sprint(v...))
 }
 
 func (l *RedirectLogger) Panicf(format string, v ...interface{}) {

--- a/testdata/slow_follower_after_compaction.txt
+++ b/testdata/slow_follower_after_compaction.txt
@@ -1,0 +1,121 @@
+# This is a regression test for https://github.com/etcd-io/raft/pull/31.
+
+# Turn off output during the setup of the test.
+log-level none
+----
+ok
+
+# Start with 3 nodes, with a limited in-flight capacity.
+add-nodes 3 voters=(1,2,3) index=10 inflight=2
+----
+ok
+
+campaign 1
+----
+ok
+
+stabilize
+----
+ok (quiet)
+
+# Propose 3 entries.
+propose 1 prop_1_12
+----
+ok
+
+propose 1 prop_1_13
+----
+ok
+
+propose 1 prop_1_14
+----
+ok
+
+stabilize
+----
+ok (quiet)
+
+# Re-enable log messages.
+log-level debug
+----
+ok
+
+# All nodes up-to-date.
+status 1
+----
+1: StateReplicate match=14 next=15
+2: StateReplicate match=14 next=15
+3: StateReplicate match=14 next=15
+
+log-level none
+----
+ok
+
+propose 1 prop_1_15
+----
+ok
+
+propose 1 prop_1_16
+----
+ok
+
+propose 1 prop_1_17
+----
+ok
+
+propose 1 prop_1_18
+----
+ok
+
+# Commit entries on nodes 1 and 2.
+stabilize 1 2
+----
+ok (quiet)
+
+log-level debug
+----
+ok
+
+# Nodes 1 and 2 up-to-date, 3 is behind and MsgApp flow is throttled.
+status 1
+----
+1: StateReplicate match=18 next=19
+2: StateReplicate match=18 next=19
+3: StateReplicate match=14 next=17 paused inflight=2[full]
+
+# Break the MsgApp flow from the leader to node 3.
+deliver-msgs drop=3
+----
+dropped: 1->3 MsgApp Term:1 Log:1/14 Commit:14 Entries:[1/15 EntryNormal "prop_1_15"]
+dropped: 1->3 MsgApp Term:1 Log:1/15 Commit:14 Entries:[1/16 EntryNormal "prop_1_16"]
+
+# Truncate the leader's log beyond node 3 log size.
+compact 1 17
+----
+1/18 EntryNormal "prop_1_18"
+
+# Trigger a round of empty MsgApp "probe" from leader. It will reach node 3
+# which will reply with a rejection MsgApp because it sees a gap in the log.
+# Node 1 will reset the MsgApp flow and send a snapshot to catch node 3 up.
+tick-heartbeat 1
+----
+ok
+
+log-level none
+----
+ok
+
+stabilize
+----
+ok (quiet)
+
+log-level debug
+----
+ok
+
+# All nodes caught up.
+status 1
+----
+1: StateReplicate match=18 next=19
+2: StateReplicate match=18 next=19
+3: StateReplicate match=18 next=19


### PR DESCRIPTION
This PR fixes a panic and adds a regression test for the following scenario:

1. The flow of `MsgApp` from the leader to a follower is throttled (i.e. `Inflights` is full).
2. The leader doesn't fetch entries from storage and only periodically sends `MsgApp`s with empty `Entries`.
3. A log compaction/truncation happens in the background, and cuts out a portion of the log beyond what's still in-flight towards the slow follower (i.e. `Progress.Match` < log cutoff)
4. Some messages to the slow follower get dropped, and as a result it replies with a rejection `MsgAppResp`.
5. The leader resets `Progress.Next = Progress.Match+1`, and is about to retry sending entries from this point.
6. In `raft.maybeSendAppend` it calls `raftLog.term` and gets 0 for the missing entry (instead of some indication/error that the log was truncated at this index). It also skips fetching entries (as in step 2), and goes ahead sending an empty `MsgApp` (with `LogTerm = 0` and a fresh `Commit` index).
7. When the follower gets this `MsgApp`, in `raftLog.maybeAppend` it a) wrongly passes the `matchTerm` check because the 0 index matches the 0 corresponding to a missing entry in the local log, b) tries to bump the `Commit` index and panics because this index is beyond its local log's `lastIndex()`.

This bug was introduced in 42419da5. Specifically, the steps (2) and (6) previously used to unconditionally fetch `raftLog.entries()`, which would return `ErrCompacted` in the above scenario, and prevent sending the problematic `MsgApp`. The commit above introduced a condition under which the `ErrCompacted` would be unnoticed.

This PR makes `maybeSendAppend` more aware of this compaction scenario, and prevents sending the problematic `MsgApp`.