### PR TITLE
raft: improve log slice allocations

### DIFF
--- a/log.go
+++ b/log.go
@@ -491,10 +491,7 @@ func (l *raftLog) slice(lo, hi uint64, maxSize entryEncodingSize) ([]pb.Entry, e
 	if hi > l.unstable.offset {
 		unstable := l.unstable.slice(max(lo, l.unstable.offset), hi)
 		if len(ents) > 0 {
-			combined := make([]pb.Entry, len(ents)+len(unstable))
-			n := copy(combined, ents)
-			copy(combined[n:], unstable)
-			ents = combined
+			ents = append(ents, unstable...)
 		} else {
 			ents = unstable
 		}

--- a/log.go
+++ b/log.go
@@ -510,7 +510,7 @@ func (l *raftLog) slice(lo, hi uint64, maxSize entryEncodingSize) ([]pb.Entry, e
 	}
 	// Otherwise, total size of unstable does not exceed maxSize-size, so total
 	// size of ents+unstable does not exceed maxSize. Simply concatenate them.
-	return append(ents, unstable...), nil
+	return extend(ents, unstable), nil
 }
 
 // l.firstIndex <= lo <= hi <= l.firstIndex + len(l.entries)

--- a/log.go
+++ b/log.go
@@ -463,40 +463,54 @@ func (l *raftLog) restore(s pb.Snapshot) {
 
 // slice returns a slice of log entries from lo through hi-1, inclusive.
 func (l *raftLog) slice(lo, hi uint64, maxSize entryEncodingSize) ([]pb.Entry, error) {
-	err := l.mustCheckOutOfBounds(lo, hi)
-	if err != nil {
+	if err := l.mustCheckOutOfBounds(lo, hi); err != nil {
 		return nil, err
 	}
 	if lo == hi {
 		return nil, nil
 	}
-	var ents []pb.Entry
-	if lo < l.unstable.offset {
-		storedEnts, err := l.storage.Entries(lo, min(hi, l.unstable.offset), uint64(maxSize))
-		if err == ErrCompacted {
-			return nil, err
-		} else if err == ErrUnavailable {
-			l.logger.Panicf("entries[%d:%d) is unavailable from storage", lo, min(hi, l.unstable.offset))
-		} else if err != nil {
-			panic(err) // TODO(bdarnell)
-		}
-
-		// check if ents has reached the size limitation
-		if uint64(len(storedEnts)) < min(hi, l.unstable.offset)-lo {
-			return storedEnts, nil
-		}
-
-		ents = storedEnts
+	if lo >= l.unstable.offset {
+		ents := limitSize(l.unstable.slice(lo, hi), maxSize)
+		// NB: use the full slice expression to protect the unstable slice from
+		// appends to the returned ents slice.
+		return ents[:len(ents):len(ents)], nil
 	}
-	if hi > l.unstable.offset {
-		unstable := l.unstable.slice(max(lo, l.unstable.offset), hi)
-		if len(ents) > 0 {
-			ents = append(ents, unstable...)
-		} else {
-			ents = unstable
-		}
+
+	cut := min(hi, l.unstable.offset)
+	ents, err := l.storage.Entries(lo, cut, uint64(maxSize))
+	if err == ErrCompacted {
+		return nil, err
+	} else if err == ErrUnavailable {
+		l.logger.Panicf("entries[%d:%d) is unavailable from storage", lo, cut)
+	} else if err != nil {
+		panic(err) // TODO(pavelkalinnikov): handle errors uniformly
 	}
-	return limitSize(ents, maxSize), nil
+	if hi <= l.unstable.offset {
+		return ents, nil
+	}
+
+	// Fast path to check if ents has reached the size limitation. Either the
+	// returned slice is shorter than requested (which means the next entry would
+	// bring it over the limit), or a single entry reaches the limit.
+	if uint64(len(ents)) < cut-lo {
+		return ents, nil
+	}
+	// Slow path computes the actual total size, so that unstable entries are cut
+	// optimally before being copied to ents slice.
+	size := entsSize(ents)
+	if size >= maxSize {
+		return ents, nil
+	}
+
+	unstable := limitSize(l.unstable.slice(l.unstable.offset, hi), maxSize-size)
+	// Total size of unstable may exceed maxSize-size only if len(unstable) == 1.
+	// If this happens, ignore this extra entry.
+	if len(unstable) == 1 && size+entsSize(unstable) > maxSize {
+		return ents, nil
+	}
+	// Otherwise, total size of unstable does not exceed maxSize-size, so total
+	// size of ents+unstable does not exceed maxSize. Simply concatenate them.
+	return append(ents, unstable...), nil
 }
 
 // l.firstIndex <= lo <= hi <= l.firstIndex + len(l.entries)

--- a/util.go
+++ b/util.go
@@ -273,19 +273,22 @@ func entsSize(ents []pb.Entry) entryEncodingSize {
 	return size
 }
 
+// limitSize returns the longest prefix of the given entries slice, such that
+// its total byte size does not exceed maxSize. Always returns a non-empty slice
+// if the input is non-empty, so, as an exception, if the size of the first
+// entry exceeds maxSize, a non-empty slice with just this entry is returned.
 func limitSize(ents []pb.Entry, maxSize entryEncodingSize) []pb.Entry {
 	if len(ents) == 0 {
 		return ents
 	}
 	size := ents[0].Size()
-	var limit int
-	for limit = 1; limit < len(ents); limit++ {
+	for limit := 1; limit < len(ents); limit++ {
 		size += ents[limit].Size()
 		if entryEncodingSize(size) > maxSize {
-			break
+			return ents[:limit]
 		}
 	}
-	return ents[:limit]
+	return ents
 }
 
 // entryPayloadSize represents the size of one or more entries' payloads.

--- a/util.go
+++ b/util.go
@@ -318,3 +318,20 @@ func assertConfStatesEquivalent(l Logger, cs1, cs2 pb.ConfState) {
 	}
 	l.Panic(err)
 }
+
+// extend appends vals to the given dst slice. It differs from the standard
+// slice append only in the way it allocates memory. If cap(dst) is not enough
+// for appending the values, precisely size len(dst)+len(vals) is allocated.
+//
+// Use this instead of standard append in situations when this is the last
+// append to dst, so there is no sense in allocating more than needed.
+func extend(dst, vals []pb.Entry) []pb.Entry {
+	need := len(dst) + len(vals)
+	if need <= cap(dst) {
+		return append(dst, vals...) // does not allocate
+	}
+	buf := make([]pb.Entry, need, need) // allocates precisely what's needed
+	copy(buf, dst)
+	copy(buf[len(dst):], vals)
+	return buf
+}


### PR DESCRIPTION
This PR improves allocations in `raftLog.slice()` method:

- appends to the slice returned by `Storage.Entries` directly instead of copying, because the semantics allow to do so (the returned slice is owned by the caller). This sometimes may avoid an allocation depending on the storage implementation.
- allocates exactly as much as needed. Previously, the entire `unstable` log could be copied and then truncated.