### PR TITLE
raft: don't panic when looking for term conflicts

### DIFF
--- a/log.go
+++ b/log.go
@@ -447,7 +447,10 @@ func (l *raftLog) matchTerm(i, term uint64) bool {
 }
 
 func (l *raftLog) maybeCommit(maxIndex, term uint64) bool {
-	if maxIndex > l.committed && l.zeroTermOnOutOfBounds(l.term(maxIndex)) == term {
+	// NB: term should never be 0 on a commit because the leader campaigns at
+	// least at term 1. But if it is 0 for some reason, we don't want to consider
+	// this a term match in case zeroTermOnOutOfBounds returns 0.
+	if maxIndex > l.committed && term != 0 && l.zeroTermOnOutOfBounds(l.term(maxIndex)) == term {
 		l.commitTo(maxIndex)
 		return true
 	}

--- a/log_test.go
+++ b/log_test.go
@@ -102,7 +102,12 @@ func TestFindConflictByTerm(t *testing.T) {
 			}})
 			l := newLog(st, raftLogger)
 			l.append(tt.ents[1:]...)
-			require.Equal(t, tt.want, l.findConflictByTerm(tt.index, tt.term))
+
+			index, term := l.findConflictByTerm(tt.index, tt.term)
+			require.Equal(t, tt.want, index)
+			wantTerm, err := l.term(index)
+			wantTerm = l.zeroTermOnOutOfBounds(wantTerm, err)
+			require.Equal(t, wantTerm, term)
 		})
 	}
 }

--- a/log_test.go
+++ b/log_test.go
@@ -55,6 +55,58 @@ func TestFindConflict(t *testing.T) {
 	}
 }
 
+func TestFindConflictByTerm(t *testing.T) {
+	ents := func(fromIndex uint64, terms []uint64) []pb.Entry {
+		e := make([]pb.Entry, 0, len(terms))
+		for i, term := range terms {
+			e = append(e, pb.Entry{Term: term, Index: fromIndex + uint64(i)})
+		}
+		return e
+	}
+	for _, tt := range []struct {
+		ents  []pb.Entry // ents[0] contains the (index, term) of the snapshot
+		index uint64
+		term  uint64
+		want  uint64
+	}{
+		// Log starts from index 1.
+		{ents: ents(0, []uint64{0, 2, 2, 5, 5, 5}), index: 100, term: 2, want: 100}, // ErrUnavailable
+		{ents: ents(0, []uint64{0, 2, 2, 5, 5, 5}), index: 5, term: 6, want: 5},
+		{ents: ents(0, []uint64{0, 2, 2, 5, 5, 5}), index: 5, term: 5, want: 5},
+		{ents: ents(0, []uint64{0, 2, 2, 5, 5, 5}), index: 5, term: 4, want: 2},
+		{ents: ents(0, []uint64{0, 2, 2, 5, 5, 5}), index: 5, term: 2, want: 2},
+		{ents: ents(0, []uint64{0, 2, 2, 5, 5, 5}), index: 5, term: 1, want: 0},
+		{ents: ents(0, []uint64{0, 2, 2, 5, 5, 5}), index: 1, term: 2, want: 1},
+		{ents: ents(0, []uint64{0, 2, 2, 5, 5, 5}), index: 1, term: 1, want: 0},
+		{ents: ents(0, []uint64{0, 2, 2, 5, 5, 5}), index: 0, term: 0, want: 0},
+		// Log with compacted entries.
+		{ents: ents(10, []uint64{3, 3, 3, 4, 4, 4}), index: 30, term: 3, want: 30}, // ErrUnavailable
+		{ents: ents(10, []uint64{3, 3, 3, 4, 4, 4}), index: 14, term: 9, want: 14},
+		{ents: ents(10, []uint64{3, 3, 3, 4, 4, 4}), index: 14, term: 4, want: 14},
+		{ents: ents(10, []uint64{3, 3, 3, 4, 4, 4}), index: 14, term: 3, want: 12},
+		{ents: ents(10, []uint64{3, 3, 3, 4, 4, 4}), index: 14, term: 2, want: 9},
+		{ents: ents(10, []uint64{3, 3, 3, 4, 4, 4}), index: 11, term: 5, want: 11},
+		{ents: ents(10, []uint64{3, 3, 3, 4, 4, 4}), index: 10, term: 5, want: 10},
+		{ents: ents(10, []uint64{3, 3, 3, 4, 4, 4}), index: 10, term: 3, want: 10},
+		{ents: ents(10, []uint64{3, 3, 3, 4, 4, 4}), index: 10, term: 2, want: 9},
+		{ents: ents(10, []uint64{3, 3, 3, 4, 4, 4}), index: 9, term: 2, want: 9}, // ErrCompacted
+		{ents: ents(10, []uint64{3, 3, 3, 4, 4, 4}), index: 4, term: 2, want: 4}, // ErrCompacted
+		{ents: ents(10, []uint64{3, 3, 3, 4, 4, 4}), index: 0, term: 0, want: 0}, // ErrCompacted
+	} {
+		t.Run("", func(t *testing.T) {
+			st := NewMemoryStorage()
+			require.NotEmpty(t, tt.ents)
+			st.ApplySnapshot(pb.Snapshot{Metadata: pb.SnapshotMetadata{
+				Index: tt.ents[0].Index,
+				Term:  tt.ents[0].Term,
+			}})
+			l := newLog(st, raftLogger)
+			l.append(tt.ents[1:]...)
+			require.Equal(t, tt.want, l.findConflictByTerm(tt.index, tt.term))
+		})
+	}
+}
+
 func TestIsUpToDate(t *testing.T) {
 	previousEnts := []pb.Entry{{Index: 1, Term: 1}, {Index: 2, Term: 2}, {Index: 3, Term: 3}}
 	raftLog := newLog(NewMemoryStorage(), raftLogger)

--- a/raft.go
+++ b/raft.go
@@ -1394,7 +1394,7 @@ func stepLeader(r *raft, m pb.Message) error {
 				//    7, the rejection points it at the end of the follower's log
 				//    which is at a higher log term than the actually committed
 				//    log.
-				nextProbeIdx = r.raftLog.findConflictByTerm(m.RejectHint, m.LogTerm)
+				nextProbeIdx, _ = r.raftLog.findConflictByTerm(m.RejectHint, m.LogTerm)
 			}
 			if pr.MaybeDecrTo(m.Index, nextProbeIdx) {
 				r.logger.Debugf("%x decreased progress of %x to [%s]", r.id, m.From, pr)
@@ -1652,24 +1652,27 @@ func (r *raft) handleAppendEntries(m pb.Message) {
 		r.send(pb.Message{To: m.From, Type: pb.MsgAppResp, Index: mlastIndex})
 		return
 	}
-
 	r.logger.Debugf("%x [logterm: %d, index: %d] rejected MsgApp [logterm: %d, index: %d] from %x",
 		r.id, r.raftLog.zeroTermOnOutOfBounds(r.raftLog.term(m.Index)), m.Index, m.LogTerm, m.Index, m.From)
 
-	// Return a hint to the leader about the maximum index and term that the two
-	// logs could be divergent at. Do this by searching through the follower's log
-	// for the maximum (index, term) pair with a term <= the MsgApp's LogTerm and
-	// an index <= the MsgApp's Index. This can help skip all indexes in the
-	// follower's uncommitted tail with terms greater than the MsgApp's LogTerm.
+	// Our log does not match the leader's at index m.Index. Return a hint to the
+	// leader - a guess on the maximal (index, term) at which the logs match. Do
+	// this by searching through the follower's log for the maximum (index, term)
+	// pair with a term <= the MsgApp's LogTerm and an index <= the MsgApp's
+	// Index. This can help skip all indexes in the follower's uncommitted tail
+	// with terms greater than the MsgApp's LogTerm.
 	//
 	// See the other caller for findConflictByTerm (in stepLeader) for a much more
 	// detailed explanation of this mechanism.
+
+	// NB: m.Index >= raftLog.committed by now (see the early return above), and
+	// raftLog.lastIndex() >= raftLog.committed by invariant, so min of the two is
+	// also >= raftLog.committed. Hence, the findConflictByTerm argument is within
+	// the valid interval, which then will return a valid (index, term) pair with
+	// a non-zero term (unless the log is empty). However, it is safe to send a zero
+	// LogTerm in this response in any case, so we don't verify it here.
 	hintIndex := min(m.Index, r.raftLog.lastIndex())
-	hintIndex = r.raftLog.findConflictByTerm(hintIndex, m.LogTerm)
-	hintTerm, err := r.raftLog.term(hintIndex)
-	if err != nil {
-		panic(fmt.Sprintf("term(%d) must be valid, but got %v", hintIndex, err))
-	}
+	hintIndex, hintTerm := r.raftLog.findConflictByTerm(hintIndex, m.LogTerm)
 	r.send(pb.Message{
 		To:         m.From,
 		Type:       pb.MsgAppResp,

--- a/raft.go
+++ b/raft.go
@@ -1909,6 +1909,8 @@ func (r *raft) abortLeaderTransfer() {
 
 // committedEntryInCurrentTerm return true if the peer has committed an entry in its term.
 func (r *raft) committedEntryInCurrentTerm() bool {
+	// NB: r.Term is never 0 on a leader, so if zeroTermOnOutOfBounds returns 0,
+	// we won't see it as a match with r.Term.
 	return r.raftLog.zeroTermOnOutOfBounds(r.raftLog.term(r.raftLog.committed)) == r.Term
 }
 


### PR DESCRIPTION
This commit fixes a hypothetical panic that may occur when a stale `MsgApp`
message arrives to a follower. The conflict searching algorithm in
`findConflictByTerm` may return a log index which is not present in the log, and
thus the `raftLog.term()` method may return an error. It is safe to ignore this
error and send `MsgAppResp` with the found index and a zero `LogTerm`.

This commit also restores the behaviour that existed before commit d0fb0cd6.
Back then, the `term()` function would silently return 0 instead of an error, and
a zero `LogTerm` would be sent with the rejecting `MsgAppResp`. After that commit,
there is a new possible panic. We remove the possibility of this panic here.