### PR TITLE
remove hexfusion from approvers list

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,7 +2,6 @@
 
 approvers:
 - ahrtr
-- hexfusion
 - mitake
 - ptabor
 - serathius


### PR DESCRIPTION
`hexfusion` was removed from etcd maintainer list at https://github.com/etcd-io/etcd/pull/15657, he isn't even a member of org `etcd-io` any more.