### PR TITLE
raft: use a type-safe slice of log entries

### DIFF
--- a/bootstrap.go
+++ b/bootstrap.go
@@ -48,7 +48,7 @@ func (rn *RawNode) Bootstrap(peers []Peer) error {
 	// TODO(tbg): remove StartNode and give the application the right tools to
 	// bootstrap the initial membership in a cleaner way.
 	rn.raft.becomeFollower(1, None)
-	ents := make([]pb.Entry, len(peers))
+	ents := make(LogRange, len(peers)) // the LogRange is valid by construction
 	for i, peer := range peers {
 		cc := pb.ConfChange{Type: pb.ConfChangeAddNode, NodeID: peer.ID, Context: peer.Context}
 		data, err := cc.Marshal()
@@ -58,7 +58,7 @@ func (rn *RawNode) Bootstrap(peers []Peer) error {
 
 		ents[i] = pb.Entry{Type: pb.EntryConfChange, Term: 1, Index: uint64(i + 1), Data: data}
 	}
-	rn.raft.raftLog.append(ents...)
+	rn.raft.raftLog.append(ents)
 
 	// Now apply them, mainly so that the application can call Campaign
 	// immediately after StartNode in tests. Note that these nodes will

--- a/bootstrap.go
+++ b/bootstrap.go
@@ -48,7 +48,7 @@ func (rn *RawNode) Bootstrap(peers []Peer) error {
 	// TODO(tbg): remove StartNode and give the application the right tools to
 	// bootstrap the initial membership in a cleaner way.
 	rn.raft.becomeFollower(1, None)
-	ents := make(LogRange, len(peers)) // the LogRange is valid by construction
+	ents := make([]pb.Entry, len(peers))
 	for i, peer := range peers {
 		cc := pb.ConfChange{Type: pb.ConfChangeAddNode, NodeID: peer.ID, Context: peer.Context}
 		data, err := cc.Marshal()
@@ -58,7 +58,11 @@ func (rn *RawNode) Bootstrap(peers []Peer) error {
 
 		ents[i] = pb.Entry{Type: pb.EntryConfChange, Term: 1, Index: uint64(i + 1), Data: data}
 	}
-	rn.raft.raftLog.append(ents)
+	rn.raft.raftLog.append(logAppend{
+		index:   0,
+		term:    0,
+		entries: ents,
+	})
 
 	// Now apply them, mainly so that the application can call Campaign
 	// immediately after StartNode in tests. Note that these nodes will

--- a/log.go
+++ b/log.go
@@ -371,11 +371,17 @@ func (l *raftLog) stableSnapTo(i uint64) { l.unstable.stableSnapTo(i) }
 func (l *raftLog) acceptUnstable() { l.unstable.acceptInProgress() }
 
 func (l *raftLog) lastTerm() uint64 {
-	t, err := l.term(l.lastIndex())
+	_, term := l.tip()
+	return term
+}
+
+func (l *raftLog) tip() (index, term uint64) {
+	index = l.lastIndex()
+	t, err := l.term(index)
 	if err != nil {
 		l.logger.Panicf("unexpected error when getting the last term (%v)", err)
 	}
-	return t
+	return index, t
 }
 
 func (l *raftLog) term(i uint64) (uint64, error) {

--- a/log_test.go
+++ b/log_test.go
@@ -49,7 +49,7 @@ func TestFindConflict(t *testing.T) {
 	for i, tt := range tests {
 		t.Run(fmt.Sprint(i), func(t *testing.T) {
 			raftLog := newLog(NewMemoryStorage(), raftLogger)
-			raftLog.append(previousEnts...)
+			raftLog.append(previousEnts)
 			require.Equal(t, tt.wconflict, raftLog.findConflict(tt.ents))
 		})
 	}
@@ -101,7 +101,7 @@ func TestFindConflictByTerm(t *testing.T) {
 				Term:  tt.ents[0].Term,
 			}})
 			l := newLog(st, raftLogger)
-			l.append(tt.ents[1:]...)
+			l.append(tt.ents[1:])
 
 			index, term := l.findConflictByTerm(tt.index, tt.term)
 			require.Equal(t, tt.want, index)
@@ -115,7 +115,7 @@ func TestFindConflictByTerm(t *testing.T) {
 func TestIsUpToDate(t *testing.T) {
 	previousEnts := []pb.Entry{{Index: 1, Term: 1}, {Index: 2, Term: 2}, {Index: 3, Term: 3}}
 	raftLog := newLog(NewMemoryStorage(), raftLogger)
-	raftLog.append(previousEnts...)
+	raftLog.append(previousEnts)
 	tests := []struct {
 		lastIndex uint64
 		term      uint64
@@ -183,10 +183,10 @@ func TestAppend(t *testing.T) {
 			storage := NewMemoryStorage()
 			storage.Append(previousEnts)
 			raftLog := newLog(storage, raftLogger)
-			require.Equal(t, tt.windex, raftLog.append(tt.ents...))
+			require.Equal(t, tt.windex, raftLog.append(tt.ents))
 			g, err := raftLog.entries(1, noLimit)
 			require.NoError(t, err)
-			require.Equal(t, tt.wents, g)
+			require.Equal(t, mustLogRange(t, tt.wents), g)
 			require.Equal(t, tt.wunstable, raftLog.unstable.offset)
 		})
 	}
@@ -287,7 +287,7 @@ func TestLogMaybeAppend(t *testing.T) {
 
 	for i, tt := range tests {
 		raftLog := newLog(NewMemoryStorage(), raftLogger)
-		raftLog.append(previousEnts...)
+		raftLog.append(previousEnts)
 		raftLog.committed = commit
 
 		t.Run(fmt.Sprint(i), func(t *testing.T) {
@@ -296,14 +296,14 @@ func TestLogMaybeAppend(t *testing.T) {
 					require.True(t, tt.wpanic)
 				}
 			}()
-			glasti, gappend := raftLog.maybeAppend(tt.index, tt.logTerm, tt.committed, tt.ents...)
+			glasti, gappend := raftLog.maybeAppend(tt.index, tt.logTerm, tt.committed, tt.ents)
 			require.Equal(t, tt.wlasti, glasti)
 			require.Equal(t, tt.wappend, gappend)
 			require.Equal(t, tt.wcommit, raftLog.committed)
 			if gappend && len(tt.ents) != 0 {
 				gents, err := raftLog.slice(raftLog.lastIndex()-uint64(len(tt.ents))+1, raftLog.lastIndex()+1, noLimit)
 				require.NoError(t, err)
-				require.Equal(t, tt.ents, gents)
+				require.Equal(t, mustLogRange(t, tt.ents), gents)
 			}
 		})
 	}
@@ -323,7 +323,7 @@ func TestCompactionSideEffects(t *testing.T) {
 	}
 	raftLog := newLog(storage, raftLogger)
 	for i = unstableIndex; i < lastIndex; i++ {
-		raftLog.append(pb.Entry{Term: i + 1, Index: i + 1})
+		raftLog.append([]pb.Entry{{Term: i + 1, Index: i + 1}})
 	}
 
 	require.True(t, raftLog.maybeCommit(lastIndex, lastTerm))
@@ -346,7 +346,7 @@ func TestCompactionSideEffects(t *testing.T) {
 	require.Equal(t, uint64(751), unstableEnts[0].Index)
 
 	prev := raftLog.lastIndex()
-	raftLog.append(pb.Entry{Index: raftLog.lastIndex() + 1, Term: raftLog.lastIndex() + 1})
+	raftLog.append([]pb.Entry{{Index: raftLog.lastIndex() + 1, Term: raftLog.lastIndex() + 1}})
 	require.Equal(t, prev+1, raftLog.lastIndex())
 
 	ents, err := raftLog.entries(raftLog.lastIndex(), noLimit)
@@ -396,7 +396,7 @@ func TestHasNextCommittedEnts(t *testing.T) {
 			require.NoError(t, storage.Append(ents[:1]))
 
 			raftLog := newLog(storage, raftLogger)
-			raftLog.append(ents...)
+			raftLog.append(ents)
 			raftLog.stableTo(4, 1)
 			raftLog.maybeCommit(5, 1)
 			raftLog.appliedTo(tt.applied, 0 /* size */)
@@ -454,7 +454,7 @@ func TestNextCommittedEnts(t *testing.T) {
 			require.NoError(t, storage.Append(ents[:1]))
 
 			raftLog := newLog(storage, raftLogger)
-			raftLog.append(ents...)
+			raftLog.append(ents)
 			raftLog.stableTo(4, 1)
 			raftLog.maybeCommit(5, 1)
 			raftLog.appliedTo(tt.applied, 0 /* size */)
@@ -465,7 +465,7 @@ func TestNextCommittedEnts(t *testing.T) {
 				newSnap.Metadata.Index++
 				raftLog.restore(newSnap)
 			}
-			require.Equal(t, tt.wents, raftLog.nextCommittedEnts(tt.allowUnstable))
+			require.Equal(t, mustLogRange(t, tt.wents), raftLog.nextCommittedEnts(tt.allowUnstable))
 		})
 	}
 }
@@ -513,7 +513,7 @@ func TestAcceptApplying(t *testing.T) {
 			require.NoError(t, storage.Append(ents[:1]))
 
 			raftLog := newLogWithSize(storage, raftLogger, maxSize)
-			raftLog.append(ents...)
+			raftLog.append(ents)
 			raftLog.stableTo(4, 1)
 			raftLog.maybeCommit(5, 1)
 			raftLog.appliedTo(3, 0 /* size */)
@@ -562,7 +562,7 @@ func TestAppliedTo(t *testing.T) {
 			require.NoError(t, storage.Append(ents[:1]))
 
 			raftLog := newLogWithSize(storage, raftLogger, maxSize)
-			raftLog.append(ents...)
+			raftLog.append(ents)
 			raftLog.stableTo(4, 1)
 			raftLog.maybeCommit(5, 1)
 			raftLog.appliedTo(3, 0 /* size */)
@@ -597,13 +597,13 @@ func TestNextUnstableEnts(t *testing.T) {
 
 			// append unstable entries to raftlog
 			raftLog := newLog(storage, raftLogger)
-			raftLog.append(previousEnts[tt.unstable-1:]...)
+			raftLog.append(previousEnts[tt.unstable-1:])
 
 			ents := raftLog.nextUnstableEnts()
 			if l := len(ents); l > 0 {
 				raftLog.stableTo(ents[l-1].Index, ents[l-1].Term)
 			}
-			require.Equal(t, tt.wents, ents)
+			require.Equal(t, mustLogRange(t, tt.wents), ents)
 			require.Equal(t, previousEnts[len(previousEnts)-1].Index+1, raftLog.unstable.offset)
 		})
 	}
@@ -629,7 +629,7 @@ func TestCommitTo(t *testing.T) {
 				}
 			}()
 			raftLog := newLog(NewMemoryStorage(), raftLogger)
-			raftLog.append(previousEnts...)
+			raftLog.append(previousEnts)
 			raftLog.committed = commit
 			raftLog.commitTo(tt.commit)
 			require.Equal(t, tt.wcommit, raftLog.committed)
@@ -651,7 +651,7 @@ func TestStableTo(t *testing.T) {
 	for i, tt := range tests {
 		t.Run(fmt.Sprint(i), func(t *testing.T) {
 			raftLog := newLog(NewMemoryStorage(), raftLogger)
-			raftLog.append([]pb.Entry{{Index: 1, Term: 1}, {Index: 2, Term: 2}}...)
+			raftLog.append([]pb.Entry{{Index: 1, Term: 1}, {Index: 2, Term: 2}})
 			raftLog.stableTo(tt.stablei, tt.stablet)
 			require.Equal(t, tt.wunstable, raftLog.unstable.offset)
 		})
@@ -688,7 +688,7 @@ func TestStableToWithSnap(t *testing.T) {
 			s := NewMemoryStorage()
 			require.NoError(t, s.ApplySnapshot(pb.Snapshot{Metadata: pb.SnapshotMetadata{Index: snapi, Term: snapt}}))
 			raftLog := newLog(s, raftLogger)
-			raftLog.append(tt.newEnts...)
+			raftLog.append(tt.newEnts)
 			raftLog.stableTo(tt.stablei, tt.stablet)
 			require.Equal(t, tt.wunstable, raftLog.unstable.offset)
 		})
@@ -761,7 +761,7 @@ func TestIsOutOfBounds(t *testing.T) {
 	storage.ApplySnapshot(pb.Snapshot{Metadata: pb.SnapshotMetadata{Index: offset}})
 	l := newLog(storage, raftLogger)
 	for i := uint64(1); i <= num; i++ {
-		l.append(pb.Entry{Index: i + offset})
+		l.append([]pb.Entry{{Index: i + offset}})
 	}
 
 	first := offset + 1
@@ -835,7 +835,7 @@ func TestTerm(t *testing.T) {
 	storage.ApplySnapshot(pb.Snapshot{Metadata: pb.SnapshotMetadata{Index: offset, Term: 1}})
 	l := newLog(storage, raftLogger)
 	for i := uint64(1); i < num; i++ {
-		l.append(pb.Entry{Index: offset + i, Term: i})
+		l.append([]pb.Entry{{Index: offset + i, Term: i}})
 	}
 
 	for i, tt := range []struct {
@@ -904,7 +904,7 @@ func TestSlice(t *testing.T) {
 	}
 	l := newLog(storage, raftLogger)
 	for i = num / 2; i < num; i++ {
-		l.append(pb.Entry{Index: offset + i, Term: offset + i})
+		l.append(mustLogRange(t, []pb.Entry{{Index: offset + i, Term: offset + i}}))
 	}
 
 	tests := []struct {
@@ -943,7 +943,7 @@ func TestSlice(t *testing.T) {
 			g, err := l.slice(tt.from, tt.to, entryEncodingSize(tt.limit))
 			require.False(t, tt.from <= offset && err != ErrCompacted)
 			require.False(t, tt.from > offset && err != nil)
-			require.Equal(t, tt.w, g)
+			require.Equal(t, mustLogRange(t, tt.w), g)
 		})
 	}
 }

--- a/log_unstable.go
+++ b/log_unstable.go
@@ -198,7 +198,7 @@ func (u *unstable) truncateAndAppend(ents LogRange) {
 	switch {
 	case fromIndex == u.offset+uint64(len(u.entries)):
 		// fromIndex is the next index in the u.entries, so append directly.
-		u.entries = append(u.entries, ents...)
+		u.entries = u.entries.Append(ents)
 	case fromIndex <= u.offset:
 		u.logger.Infof("replace the unstable entries from index %d", fromIndex)
 		// The log is being truncated to before our current offset

--- a/log_unstable_test.go
+++ b/log_unstable_test.go
@@ -244,7 +244,7 @@ func TestUnstableNextEntries(t *testing.T) {
 				logger:           raftLogger,
 			}
 			res := u.nextEntries()
-			require.Equal(t, tt.wentries, res)
+			require.Equal(t, mustLogRange(t, tt.wentries), res)
 		})
 	}
 }
@@ -511,7 +511,7 @@ func TestUnstableTruncateAndAppend(t *testing.T) {
 
 		woffset           uint64
 		woffsetInProgress uint64
-		wentries          []pb.Entry
+		wentries          LogRange
 	}{
 		// append to the end
 		{

--- a/node.go
+++ b/node.go
@@ -77,7 +77,7 @@ type Ready struct {
 	// If async storage writes are enabled, this field does not need to be acted
 	// on immediately. It will be reflected in a MsgStorageAppend message in the
 	// Messages slice.
-	Entries []pb.Entry
+	Entries LogRange
 
 	// Snapshot specifies the snapshot to be saved to stable storage.
 	//
@@ -93,7 +93,7 @@ type Ready struct {
 	// If async storage writes are enabled, this field does not need to be acted
 	// on immediately. It will be reflected in a MsgStorageApply message in the
 	// Messages slice.
-	CommittedEntries []pb.Entry
+	CommittedEntries LogRange
 
 	// Messages specifies outbound messages.
 	//

--- a/raft.go
+++ b/raft.go
@@ -757,7 +757,10 @@ func (r *raft) reset(term uint64) {
 }
 
 func (r *raft) appendEntry(es ...pb.Entry) (accepted bool) {
-	li := r.raftLog.lastIndex()
+	li, lt := r.raftLog.tip()
+	if r.Term < lt {
+		r.logger.Panicf("%x appending out-of-order term: %d < %d", r.id, r.Term, lt)
+	}
 	for i := range es {
 		es[i].Term = r.Term
 		es[i].Index = li + 1 + uint64(i)
@@ -1724,6 +1727,16 @@ func (r *raft) restore(s pb.Snapshot) bool {
 		// state when this method is called.
 		r.logger.Warningf("%x attempted to restore snapshot as leader; should never happen", r.id)
 		r.becomeFollower(r.Term+1, None)
+		return false
+	}
+
+	// Another defense-in-depth: the follower is seeing a snapshot at a bigger
+	// term, but hasn't updated its own term.
+	if s.Metadata.Term > r.Term {
+		r.logger.Warningf("%x attempted to restore snapshot at term %d while being at earlier term %d; "+
+			"should transition to follower at a larger term first",
+			r.id, s.Metadata.Term, r.Term)
+		r.becomeFollower(s.Metadata.Term, None)
 		return false
 	}
 

--- a/raft_snap_test.go
+++ b/raft_snap_test.go
@@ -17,6 +17,8 @@ package raft
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	pb "go.etcd.io/raft/v3/raftpb"
 )
 
@@ -33,8 +35,8 @@ var (
 func TestSendingSnapshotSetPendingSnapshot(t *testing.T) {
 	storage := newTestMemoryStorage(withPeers(1))
 	sm := newTestRaft(1, 10, 1, storage)
-	sm.restore(testingSnap)
-
+	sm.becomeFollower(testingSnap.Metadata.Term, 0)
+	require.True(t, sm.restore(testingSnap))
 	sm.becomeCandidate()
 	sm.becomeLeader()
 
@@ -51,8 +53,8 @@ func TestSendingSnapshotSetPendingSnapshot(t *testing.T) {
 func TestPendingSnapshotPauseReplication(t *testing.T) {
 	storage := newTestMemoryStorage(withPeers(1, 2))
 	sm := newTestRaft(1, 10, 1, storage)
-	sm.restore(testingSnap)
-
+	sm.becomeFollower(testingSnap.Metadata.Term, 0)
+	require.True(t, sm.restore(testingSnap))
 	sm.becomeCandidate()
 	sm.becomeLeader()
 
@@ -68,8 +70,8 @@ func TestPendingSnapshotPauseReplication(t *testing.T) {
 func TestSnapshotFailure(t *testing.T) {
 	storage := newTestMemoryStorage(withPeers(1, 2))
 	sm := newTestRaft(1, 10, 1, storage)
-	sm.restore(testingSnap)
-
+	sm.becomeFollower(testingSnap.Metadata.Term, 0)
+	require.True(t, sm.restore(testingSnap))
 	sm.becomeCandidate()
 	sm.becomeLeader()
 
@@ -91,8 +93,8 @@ func TestSnapshotFailure(t *testing.T) {
 func TestSnapshotSucceed(t *testing.T) {
 	storage := newTestMemoryStorage(withPeers(1, 2))
 	sm := newTestRaft(1, 10, 1, storage)
-	sm.restore(testingSnap)
-
+	sm.becomeFollower(testingSnap.Metadata.Term, 0)
+	require.True(t, sm.restore(testingSnap))
 	sm.becomeCandidate()
 	sm.becomeLeader()
 
@@ -114,8 +116,8 @@ func TestSnapshotSucceed(t *testing.T) {
 func TestSnapshotAbort(t *testing.T) {
 	storage := newTestMemoryStorage(withPeers(1, 2))
 	sm := newTestRaft(1, 10, 1, storage)
-	sm.restore(testingSnap)
-
+	sm.becomeFollower(testingSnap.Metadata.Term, 0)
+	require.True(t, sm.restore(testingSnap))
 	sm.becomeCandidate()
 	sm.becomeLeader()
 

--- a/raft_test.go
+++ b/raft_test.go
@@ -2767,7 +2767,7 @@ func TestLeaderIncreaseNext(t *testing.T) {
 
 	for i, tt := range tests {
 		sm := newTestRaft(1, 10, 1, newTestMemoryStorage(withPeers(1, 2)))
-		sm.raftLog.append(previousEnts)
+		sm.raftLog.append(logAppend{entries: previousEnts})
 		sm.becomeCandidate()
 		sm.becomeLeader()
 		sm.prs.Progress[2].State = tt.state
@@ -3107,7 +3107,7 @@ func TestRestoreIgnoreSnapshot(t *testing.T) {
 	commit := uint64(1)
 	storage := newTestMemoryStorage(withPeers(1, 2))
 	sm := newTestRaft(1, 10, 1, storage)
-	sm.raftLog.append(previousEnts)
+	sm.raftLog.append(logAppend{entries: previousEnts})
 	sm.raftLog.commitTo(commit)
 
 	s := pb.Snapshot{

--- a/raft_test.go
+++ b/raft_test.go
@@ -2767,7 +2767,7 @@ func TestLeaderIncreaseNext(t *testing.T) {
 
 	for i, tt := range tests {
 		sm := newTestRaft(1, 10, 1, newTestMemoryStorage(withPeers(1, 2)))
-		sm.raftLog.append(previousEnts...)
+		sm.raftLog.append(previousEnts)
 		sm.becomeCandidate()
 		sm.becomeLeader()
 		sm.prs.Progress[2].State = tt.state
@@ -3068,7 +3068,7 @@ func TestRestoreLearnerPromotion(t *testing.T) {
 	require.True(t, !sm.isLearner)
 }
 
-// TestLearnerReceiveSnapshot tests that a learner can receive a snpahost from leader
+// TestLearnerReceiveSnapshot tests that a learner can receive a snapshot from leader.
 func TestLearnerReceiveSnapshot(t *testing.T) {
 	// restore the state machine from a snapshot so it has a compacted log and a snapshot
 	s := pb.Snapshot{
@@ -3107,7 +3107,7 @@ func TestRestoreIgnoreSnapshot(t *testing.T) {
 	commit := uint64(1)
 	storage := newTestMemoryStorage(withPeers(1, 2))
 	sm := newTestRaft(1, 10, 1, storage)
-	sm.raftLog.append(previousEnts...)
+	sm.raftLog.append(previousEnts)
 	sm.raftLog.commitTo(commit)
 
 	s := pb.Snapshot{
@@ -3277,7 +3277,7 @@ func TestStepIgnoreConfig(t *testing.T) {
 	index := r.raftLog.lastIndex()
 	pendingConfIndex := r.pendingConfIndex
 	r.Step(pb.Message{From: 1, To: 1, Type: pb.MsgProp, Entries: []pb.Entry{{Type: pb.EntryConfChange}}})
-	wents := []pb.Entry{{Type: pb.EntryNormal, Term: 1, Index: 3, Data: nil}}
+	wents := mustLogRange(t, []pb.Entry{{Type: pb.EntryNormal, Term: 1, Index: 3, Data: nil}})
 	ents, err := r.raftLog.entries(index+1, noLimit)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)

--- a/rafttest/interaction_env.go
+++ b/rafttest/interaction_env.go
@@ -83,7 +83,7 @@ type Storage interface {
 	SetHardState(state pb.HardState) error
 	ApplySnapshot(pb.Snapshot) error
 	Compact(newFirstIndex uint64) error
-	Append([]pb.Entry) error
+	Append(raft.LogRange) error
 }
 
 // raftConfigStub sets up a raft.Config stub with reasonable testing defaults.

--- a/range.go
+++ b/range.go
@@ -1,0 +1,75 @@
+// Copyright 2023 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package raft
+
+import (
+	"fmt"
+	"testing"
+
+	pb "go.etcd.io/raft/v3/raftpb"
+)
+
+// LogRange represents a range of contiguous log entries. This entries slice has
+// been verified to have the following properties:
+//   - entries[i+1].Index == entries[i].Index + 1
+//   - entries[i+1].Term >= entries[i].Term
+//
+// TODO(pavelkalinnikov): make it harder to convert from []pb.Entry to LogRange.
+type LogRange []pb.Entry
+
+// VerifyLogRange checks that the given slice represents a valid range of
+// contiguous log entries that can be appended after (index, term).
+func VerifyLogRange(index, term uint64, ents []pb.Entry) (LogRange, error) {
+	for i := range ents {
+		index++
+		if got := ents[i].Index; got != index {
+			return nil, fmt.Errorf("entry[%d].Index is %d, want %d", i, got, index)
+		}
+		curTerm := ents[i].Term
+		if curTerm < term {
+			return nil, fmt.Errorf("entry[%d].Term is %d, want at least %d", i, curTerm, term)
+		}
+		term = curTerm
+	}
+	return ents, nil
+}
+
+// Append appends a valid log range to this one. It is like a regular slice
+// append, but verifies that the resulting slice is a valid log range.
+//
+// TODO(pavelkalinnikov): consider returning error instead of panic.
+func (r LogRange) Append(other LogRange) LogRange {
+	if lr := len(r); lr != 0 && len(other) != 0 {
+		if last, index := r[lr-1].Index, other[0].Index; index != last+1 {
+			panic(fmt.Sprintf("disjoint ranges: last index %d, next %d, want %d", last, index, last+1))
+		}
+		if last, term := r[lr-1].Term, other[0].Term; term < last {
+			panic(fmt.Sprintf("appending non-monotonic term: last term %d, next %d", last, term))
+		}
+	}
+	return append(r, other...)
+}
+
+func mustLogRange(t *testing.T, ents []pb.Entry) LogRange {
+	t.Helper()
+	if len(ents) == 0 {
+		return ents
+	}
+	res, err := VerifyLogRange(ents[0].Index-1, ents[0].Term, ents)
+	if err != nil {
+		t.Fatalf("VerifyLogRange: %v", err)
+	}
+	return res
+}

--- a/rawnode_test.go
+++ b/rawnode_test.go
@@ -665,10 +665,10 @@ func TestRawNodeReadIndex(t *testing.T) {
 // requires the application to bootstrap the state, i.e. it does not accept peers
 // and will not create faux configuration change entries.
 func TestRawNodeStart(t *testing.T) {
-	entries := []pb.Entry{
+	entries := mustLogRange(t, []pb.Entry{
 		{Term: 1, Index: 2, Data: nil},           // empty entry
 		{Term: 1, Index: 3, Data: []byte("foo")}, // empty entry
-	}
+	})
 	want := Ready{
 		SoftState:        &SoftState{Lead: 1, RaftState: StateLeader},
 		HardState:        pb.HardState{Term: 1, Commit: 3, Vote: 1},

--- a/storage.go
+++ b/storage.go
@@ -250,7 +250,7 @@ func (ms *MemoryStorage) Compact(compactIndex uint64) error {
 // Append the new entries to storage.
 // TODO (xiangli): ensure the entries are continuous and
 // entries[0].Index > ms.entries[0].Index
-func (ms *MemoryStorage) Append(entries []pb.Entry) error {
+func (ms *MemoryStorage) Append(entries LogRange) error {
 	if len(entries) == 0 {
 		return nil
 	}

--- a/util.go
+++ b/util.go
@@ -273,7 +273,7 @@ func entsSize(ents []pb.Entry) entryEncodingSize {
 	return size
 }
 
-func limitSize(ents []pb.Entry, maxSize entryEncodingSize) []pb.Entry {
+func limitSize(ents LogRange, maxSize entryEncodingSize) LogRange {
 	if len(ents) == 0 {
 		return ents
 	}
@@ -300,7 +300,7 @@ func payloadSize(e pb.Entry) entryPayloadSize {
 }
 
 // payloadsSize is the size of the payloads of the provided entries.
-func payloadsSize(ents []pb.Entry) entryPayloadSize {
+func payloadsSize(ents LogRange) entryPayloadSize {
 	var s entryPayloadSize
 	for _, e := range ents {
 		s += payloadSize(e)

--- a/util_test.go
+++ b/util_test.go
@@ -41,10 +41,10 @@ func TestDescribeEntry(t *testing.T) {
 }
 
 func TestLimitSize(t *testing.T) {
-	ents := []pb.Entry{{Index: 4, Term: 4}, {Index: 5, Term: 5}, {Index: 6, Term: 6}}
+	ents := mustLogRange(t, []pb.Entry{{Index: 4, Term: 4}, {Index: 5, Term: 5}, {Index: 6, Term: 6}})
 	tests := []struct {
 		maxsize  uint64
-		wentries []pb.Entry
+		wentries LogRange
 	}{
 		{math.MaxUint64, []pb.Entry{{Index: 4, Term: 4}, {Index: 5, Term: 5}, {Index: 6, Term: 6}}},
 		// Even if maxsize is zero, the first entry should be returned.


### PR DESCRIPTION
All `[]pb.Entry` slices that `raft` works with are contiguous valid log ranges, for which the following invariants hold:

- `entries[i+1].Index == entries[i].Index + 1`
- `entries[i+1].Term >= entries[i].Term`
- TODO: we could also verify that `Term > 0` and `Index > 0`; the only zero case is the "sentinel" `(0, 0)` entry.

Much of the code implicitly assumes this, and will behave arbitrarily if this isn't true. This PR adds a `LogRange` type which is a type-safe slice promising these invariants explicitly.

---

Additionally, entry slices are often used in conjunction with an `(index, term)` tuple which describes the entry that immediately precedes the slice, i.e.:

- `entries[0].Index == index + 1`
- `entries[0].Term >= term`

For example, the log append handling stack (starting from a `MsgApp` message handler all the way down to `unstable` and `Storage`) operates with such a construct, effectively a "conditional put".

We have seen incorrect (not adhering to this invariant) `MsgApp` being sent (#47), or received (https://github.com/etcd-io/etcd/issues/14735). A type-safe / verified entries "append" slice should reduce the chance of such bugs, or at least make them better discoverable.

This PR introduces such a type, `logAppend`, and refactors the `raftLog` type to take advantage of it. This also makes the code cleaner.

This type could evolve into "the only" way of storing and passing entry slices around. Effectively, the log (or its sub-range) is always an `(index, term)` indicating a compaction or other "watermark", plus a `[]pb.Entry` suffix of currently available entries. This seems true for `unstable` and `raftLog` types. Another example is the `MemoryStorage`.