### PR TITLE
Updated go to latest patch release 1.19.9

### DIFF
--- a/.github/workflows/govuln.yaml
+++ b/.github/workflows/govuln.yaml
@@ -7,6 +7,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.19.7"
+          go-version: "1.19.9"
       - run: date
       - run: go install golang.org/x/vuln/cmd/govulncheck@latest && govulncheck ./...

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -7,7 +7,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.19.7"
+          go-version: "1.19.9"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.19.7"
+          go-version: "1.19.9"
       - env:
           TARGET: ${{ matrix.target }}
         run: |


### PR DESCRIPTION
Go 1.19.9 was released 2023-05-02, we should consider updating to stay aligned with main etcd repo go version.

https://go.dev/doc/devel/release#go1.19.minor

> The update includes three security fixes to the html/template package, as well as bug fixes to the compiler, the runtime, and the crypto/tls and syscall packages. See the [Go 1.19.9 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.19.9+label%3ACherryPickApproved) on our issue tracker for details. 