### PR TITLE
Add AllowInvariantViolations config, commit index regression test and…

### DIFF
--- a/rafttest/interaction_env_handler.go
+++ b/rafttest/interaction_env_handler.go
@@ -126,6 +126,20 @@ func (env *InteractionEnv) Handle(t *testing.T, d datadriven.TestData) string {
 		//
 		// transfer-leadership from=1 to=4
 		err = env.handleTransferLeadership(t, d)
+	case "truncate":
+		// Truncates the log on the node at index idx, reset it to the former status where
+		// the last truncate_at was called.
+		// Example:
+		//
+		// truncate <id>
+		err = env.handleTruncate(t, d)
+	case "truncate_at":
+		// Set a checkpoint for the following truncation. Later call of truncate will truncate the
+		// log from where this truncate_at is called.
+		// Example:
+		//
+		// truncate_at <id>
+		err = env.handleTruncateAt(t, d)
 	case "propose":
 		// Propose an entry.
 		//

--- a/rafttest/interaction_env_handler_truncate.go
+++ b/rafttest/interaction_env_handler_truncate.go
@@ -1,0 +1,47 @@
+// Copyright 2019 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rafttest
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/datadriven"
+)
+
+func (env *InteractionEnv) handleTruncateAt(t *testing.T, d datadriven.TestData) error {
+	idx := firstAsNodeIdx(t, d)
+	return env.TruncateAt(idx)
+}
+
+func (env *InteractionEnv) handleTruncate(t *testing.T, d datadriven.TestData) error {
+	idx := firstAsNodeIdx(t, d)
+	return env.Truncate(idx)
+}
+
+func (env *InteractionEnv) TruncateAt(idx int) error {
+	storage := env.Nodes[idx].Storage.(*snapOverrideStorage)
+	if err := storage.TruncateAt(); err != nil {
+		return err
+	}
+	return env.RaftLog(idx)
+}
+
+func (env *InteractionEnv) Truncate(idx int) error {
+	storage := env.Nodes[idx].Storage.(*snapOverrideStorage)
+	if err := storage.Truncate(); err != nil {
+		return err
+	}
+	return env.RaftLog(idx)
+}

--- a/rafttest/storage.go
+++ b/rafttest/storage.go
@@ -1,0 +1,41 @@
+package rafttest
+
+import (
+	"go.etcd.io/raft/v3"
+	pb "go.etcd.io/raft/v3/raftpb"
+)
+
+type snapOverrideStorage struct {
+	Storage
+	snapshotOverride func() (pb.Snapshot, error)
+	truncatedFrom    pb.Snapshot
+}
+
+func newSnapOverrideStorage(f func() (pb.Snapshot, error)) *snapOverrideStorage {
+	return &snapOverrideStorage{
+		Storage:          raft.NewMemoryStorage(),
+		snapshotOverride: f,
+	}
+}
+
+func (s *snapOverrideStorage) Snapshot() (pb.Snapshot, error) {
+	if s.snapshotOverride != nil {
+		return s.snapshotOverride()
+	}
+	return s.Storage.Snapshot()
+}
+
+func (s *snapOverrideStorage) TruncateAt() error {
+	var err error
+	s.truncatedFrom, err = s.snapshotOverride()
+	return err
+}
+
+func (s *snapOverrideStorage) Truncate() error {
+	s.Storage = raft.NewMemoryStorage()
+	err := s.Storage.ApplySnapshot(s.truncatedFrom)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/testdata/commit_index_regression.txt
+++ b/testdata/commit_index_regression.txt
@@ -1,0 +1,174 @@
+# Test when a follower does not persist its committed entries.
+# For more background, see
+# https://github.com/etcd-io/etcd/issues/10166
+# and
+# https://github.com/etcd-io/raft/pull/25
+
+log-level none
+----
+ok
+
+# Add 3 nodes with allow-invariant-violations enabled. Without this option, the
+# test will panic.
+add-nodes 3 voters=(1,2,3) index=10 allow-invariant-violations=true
+----
+ok
+
+campaign 1
+----
+ok
+
+stabilize
+----
+ok (quiet)
+
+propose 1 prop_1_12
+----
+ok
+
+stabilize
+----
+ok (quiet)
+
+# Set a checkpoint for node 3. This is the snapshot from which node 3 will recover.
+# Any changes after this snapshot will be lost. i.e. node 3 is truncated from this point.
+truncate_at 3
+----
+ok (quiet)
+
+propose 1 prop_1_13
+----
+ok
+
+propose 1 prop_1_14
+----
+ok
+
+propose 1 prop_1_15
+----
+ok
+
+# Send MsgApp to nodes 2 and 3
+stabilize 1
+----
+ok (quiet)
+
+# Reply to node 1, replicate a copy but not yet commit the entries.
+stabilize 2 3
+----
+ok (quiet)
+
+# Now node 1 commits the entry, and the commit msg to node 3 is pending
+stabilize 1 2
+----
+ok (quiet)
+
+log-level debug
+----
+ok
+
+# Truncate the log of node 3. Its commit index is regressed.
+truncate 3
+----
+log is empty: first index=13, last index=12
+
+# Node 3 will receive a commit message with index 15, but it does not have that
+# entry since its log is truncated.
+stabilize
+----
+> 3 receiving messages
+  1->3 MsgApp Term:1 Log:1/15 Commit:13
+  DEBUG 3 [logterm: 0, index: 15] rejected MsgApp [logterm: 1, index: 15] from 1
+  1->3 MsgApp Term:1 Log:1/15 Commit:14
+  DEBUG 3 [logterm: 0, index: 15] rejected MsgApp [logterm: 1, index: 15] from 1
+  1->3 MsgApp Term:1 Log:1/15 Commit:15
+  DEBUG 3 [logterm: 0, index: 15] rejected MsgApp [logterm: 1, index: 15] from 1
+> 3 handling Ready
+  Ready MustSync=false:
+  Messages:
+  3->1 MsgAppResp Term:1 Log:1/15 Rejected (Hint: 12)
+  3->1 MsgAppResp Term:1 Log:1/15 Rejected (Hint: 12)
+  3->1 MsgAppResp Term:1 Log:1/15 Rejected (Hint: 12)
+> 1 receiving messages
+  3->1 MsgAppResp Term:1 Log:1/15 Rejected (Hint: 12)
+  DEBUG 1 received MsgAppResp(rejected, hint: (index 12, term 1)) from 3 for index 15
+  3->1 MsgAppResp Term:1 Log:1/15 Rejected (Hint: 12)
+  DEBUG 1 received MsgAppResp(rejected, hint: (index 12, term 1)) from 3 for index 15
+  3->1 MsgAppResp Term:1 Log:1/15 Rejected (Hint: 12)
+  DEBUG 1 received MsgAppResp(rejected, hint: (index 12, term 1)) from 3 for index 15
+
+# Trigger a round of empty MsgApp "probe" from leader. Normally this will panic,
+# since the durability request of raft is violated. However, if the user want to loosen
+# the invariant checks, we can try to recover from it with a naive approach.
+tick-heartbeat 1
+----
+ok
+
+stabilize
+----
+> 1 handling Ready
+  Ready MustSync=false:
+  Messages:
+  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:15
+  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:15
+> 2 receiving messages
+  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:15
+> 3 receiving messages
+  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:15
+  FATAL tocommit(15) is out of range [lastIndex(12)]. Was the raft log corrupted, truncated, or lost?
+> 2 handling Ready
+  Ready MustSync=false:
+  Messages:
+  2->1 MsgHeartbeatResp Term:1 Log:0/0
+> 3 handling Ready
+  Ready MustSync=false:
+  Messages:
+  3->1 MsgHeartbeatResp Term:1 Log:0/0 Rejected (Hint: 12) Commit:15
+> 1 receiving messages
+  2->1 MsgHeartbeatResp Term:1 Log:0/0
+  3->1 MsgHeartbeatResp Term:1 Log:0/0 Rejected (Hint: 12) Commit:15
+  DEBUG 1 received MsgHeartbeatResp(rejected, hint: (index 12)) from 3 for index 15
+  DEBUG 1 decreased progress of 3 to [StateReplicate match=12 next=13]
+> 1 handling Ready
+  Ready MustSync=false:
+  Messages:
+  1->3 MsgApp Term:1 Log:1/12 Commit:15 Entries:[1/13 EntryNormal "prop_1_13", 1/14 EntryNormal "prop_1_14", 1/15 EntryNormal "prop_1_15"]
+> 3 receiving messages
+  1->3 MsgApp Term:1 Log:1/12 Commit:15 Entries:[1/13 EntryNormal "prop_1_13", 1/14 EntryNormal "prop_1_14", 1/15 EntryNormal "prop_1_15"]
+  INFO replace the unstable entries from index 13
+> 3 handling Ready
+  Ready MustSync=true:
+  HardState Term:1 Vote:1 Commit:15
+  Entries:
+  1/13 EntryNormal "prop_1_13"
+  1/14 EntryNormal "prop_1_14"
+  1/15 EntryNormal "prop_1_15"
+  CommittedEntries:
+  1/13 EntryNormal "prop_1_13"
+  1/14 EntryNormal "prop_1_14"
+  1/15 EntryNormal "prop_1_15"
+  Messages:
+  3->1 MsgAppResp Term:1 Log:0/15
+> 1 receiving messages
+  3->1 MsgAppResp Term:1 Log:0/15
+
+# All nodes caught up.
+status 1
+----
+1: StateReplicate match=15 next=16
+2: StateReplicate match=15 next=16
+3: StateReplicate match=15 next=16
+
+raft-log 1
+----
+1/11 EntryNormal ""
+1/12 EntryNormal "prop_1_12"
+1/13 EntryNormal "prop_1_13"
+1/14 EntryNormal "prop_1_14"
+1/15 EntryNormal "prop_1_15"
+
+raft-log 3
+----
+1/13 EntryNormal "prop_1_13"
+1/14 EntryNormal "prop_1_14"
+1/15 EntryNormal "prop_1_15"


### PR DESCRIPTION
Attempt to resolve part of https://github.com/etcd-io/etcd/issues/10166, https://github.com/etcd-io/raft/issues/18, and https://github.com/etcd-io/raft/issues/29.
IMHO it is hard to keep backwards compatible while introducing event-based log, since it will require the users to implement the new Event method in the log interface if they have implemented their own loggers. 
Therefore, this commit only tries to introduce a new config option AllowInvariantViolation. If enabled, raft will try to recover from the commit index regression problem described in the above issues, rather than panic directly. The approach is exactly the one used in https://github.com/etcd-io/raft/pull/25. This may not be suitable for more complex situations e.g. when leader transfer is happening, but is enough for simple case like the one in the test. 
I'm very willing to discuss more about this.