### PR TITLE
tracker: fix byte counter leak in Inflights tracker

### DIFF
--- a/tracker/inflights.go
+++ b/tracker/inflights.go
@@ -137,6 +137,7 @@ func (in *Inflights) Count() int { return in.count }
 
 // reset frees all inflights.
 func (in *Inflights) reset() {
-	in.count = 0
 	in.start = 0
+	in.count = 0
+	in.bytes = 0
 }


### PR DESCRIPTION
This change fixes a bug in the Inflights tracker. The reset() method did not zero the bytes counter, which could result in a quota "leak" and delayed or stalled MsgApp sends.

The reset() method is used when the replication flow changes state between Probe/Replicate/Snapshot. If reset() is not called at an appropriate moment, when Inflights.Full(), the bytes counter would stay over the budget and stall the flow.

The test added in this PR failed before, and passes after the change.