### PR TITLE
deprecate `RawNode.TickQuiesced()`

### DIFF
--- a/rawnode.go
+++ b/rawnode.go
@@ -72,6 +72,8 @@ func (rn *RawNode) Tick() {
 //
 // WARNING: Be very careful about using this method as it subverts the Raft
 // state machine. You should probably be using Tick instead.
+//
+// DEPRECATED: This method will be removed in a future release.
 func (rn *RawNode) TickQuiesced() {
 	rn.raft.electionElapsed++
 }


### PR DESCRIPTION
`TickQuiesced()` was originally added for use with range quiescence in CockroachDB, but hasn't been in use since 2018. This patch marks it as deprecated, to be removed in a future release.

See https://github.com/cockroachdb/cockroach/pull/24956.