### PR TITLE
Updated go to latest patch release 1.19.11

### DIFF
--- a/.github/workflows/govuln.yaml
+++ b/.github/workflows/govuln.yaml
@@ -7,6 +7,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.19.10"
+          go-version: "1.19.11"
       - run: date
       - run: go install golang.org/x/vuln/cmd/govulncheck@latest && govulncheck ./...

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -7,7 +7,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.19.10"
+          go-version: "1.19.11"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.19.10"
+          go-version: "1.19.11"
       - env:
           TARGET: ${{ matrix.target }}
         run: |


### PR DESCRIPTION
Maintenance to keep raft using latest go patch release for workflows and stay in sync with `etcd-io/etcd`.

Refer: https://github.com/golang/go/issues?q=milestone%3AGo1.19.11+label%3ACherryPickApproved