### PR TITLE
Reduce chance of duelling leaders

### DIFF
--- a/raft.go
+++ b/raft.go
@@ -838,13 +838,21 @@ func (r *raft) becomeFollower(term uint64, lead uint64) {
 	r.logger.Infof("%x became follower at term %d", r.id, r.Term)
 }
 
+func (r *raft) nextTerm() uint64 {
+  // Term = [epoch:48; rand:16]
+  var cepoch uint64 = (r.Term & 0xffff_ffff_ffff_0000) >> 16
+  var tepoch uint64 = (cepoch + 1) << 16
+  var trdm uint64   = uint64(globalRand.Intn(65536)) & 0xffff
+  return tepoch | trdm
+}
+
 func (r *raft) becomeCandidate() {
 	// TODO(xiangli) remove the panic when the raft implementation is stable
 	if r.state == StateLeader {
 		panic("invalid transition [leader -> candidate]")
 	}
 	r.step = stepCandidate
-	r.reset(r.Term + 1)
+	r.reset(r.nextTerm())
 	r.tick = r.tickElection
 	r.Vote = r.id
 	r.state = StateCandidate
@@ -943,7 +951,7 @@ func (r *raft) campaign(t CampaignType) {
 		r.becomePreCandidate()
 		voteMsg = pb.MsgPreVote
 		// PreVote RPCs are sent for the next term before we've incremented r.Term.
-		term = r.Term + 1
+		term = r.nextTerm()
 	} else {
 		r.becomeCandidate()
 		voteMsg = pb.MsgVote


### PR DESCRIPTION
Currently if multiple replicas concurrently try to recover from a failed leader, they can collide and must retry.
This is likely to occur in well behaved networks, since replicas will detect the fault at similar times.
It is also exacerbated as the number of replicas increase.

This PR uses randomness to reduce the chance of collisions by spreading out the candidates over $2^{16}$ terms, and effectively electing the candidate which chooses the highest term.

Since this is equivalent to each candidate being partitioned from the cluster until it hits its chosen term, there should be no interactions with the rest of the consensus protocol.

The downside of this approach is that if some candidate with a higher term becomes a candidate after a lower termed candidate is already elected, it will be prolong the outage.
This case is less likely to occur if PreVote is enabled.

The graph below compares time to recovery when the leader fails, which we define as the maximum interval without any committed requests.

![ttr etcd](https://github.com/etcd-io/raft/assets/11444677/93948a90-1f31-4b3f-af80-6c19a6c6a303)