### PR TITLE
remove redundant joint config check

### DIFF
--- a/confchange/confchange.go
+++ b/confchange/confchange.go
@@ -100,10 +100,6 @@ func (c Changer) LeaveJoint() (tracker.Config, tracker.ProgressMap, error) {
 		err := errors.New("can't leave a non-joint config")
 		return c.err(err)
 	}
-	if len(outgoing(cfg.Voters)) == 0 {
-		err := fmt.Errorf("configuration is not joint: %v", cfg)
-		return c.err(err)
-	}
 	for id := range cfg.LearnersNext {
 		nilAwareAdd(&cfg.Learners, id)
 		prs[id].IsLearner = true


### PR DESCRIPTION
This check is exactly equal to the above `!joint()` check.

Resolves #90.