### PR TITLE
Bump versions for golang, golangci-lint and protoc

### DIFF
--- a/.github/workflows/govuln.yaml
+++ b/.github/workflows/govuln.yaml
@@ -7,6 +7,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.19.11"
+          go-version: "1.19.12"
       - run: date
       - run: go install golang.org/x/vuln/cmd/govulncheck@latest && govulncheck ./...

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -7,7 +7,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.19.11"
+          go-version: "1.19.12"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -15,5 +15,5 @@ jobs:
       - name: protoc
         uses: arduino/setup-protoc@v1
         with:
-          version: '3.14.0'
+          version: '3.20.3'
       - run: make verify

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -11,7 +11,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.49.0
+          version: v1.53.3
       - name: protoc
         uses: arduino/setup-protoc@v1
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.19.11"
+          go-version: "1.19.12"
       - env:
           TARGET: ${{ matrix.target }}
         run: |

--- a/example_test.go
+++ b/example_test.go
@@ -18,10 +18,10 @@ import (
 	pb "go.etcd.io/raft/v3/raftpb"
 )
 
-func applyToStore(ents []pb.Entry)    {}
-func sendMessages(msgs []pb.Message)  {}
-func saveStateToDisk(st pb.HardState) {}
-func saveToDisk(ents []pb.Entry)      {}
+func applyToStore(_ []pb.Entry)      {}
+func sendMessages(_ []pb.Message)    {}
+func saveStateToDisk(_ pb.HardState) {}
+func saveToDisk(_ []pb.Entry)        {}
 
 func ExampleNode() {
 	c := &Config{}

--- a/node_test.go
+++ b/node_test.go
@@ -1090,7 +1090,7 @@ type ignoreSizeHintMemStorage struct {
 	*MemoryStorage
 }
 
-func (s *ignoreSizeHintMemStorage) Entries(lo, hi uint64, maxSize uint64) ([]raftpb.Entry, error) {
+func (s *ignoreSizeHintMemStorage) Entries(lo, hi uint64, _ uint64) ([]raftpb.Entry, error) {
 	return s.MemoryStorage.Entries(lo, hi, math.MaxUint64)
 }
 

--- a/rafttest/interaction_env_handler.go
+++ b/rafttest/interaction_env_handler.go
@@ -84,7 +84,7 @@ func (env *InteractionEnv) Handle(t *testing.T, d datadriven.TestData) string {
 		// Example:
 		//
 		// log-level WARN
-		err = env.handleLogLevel(t, d)
+		err = env.handleLogLevel(d)
 	case "raft-log":
 		// Print the Raft log.
 		//

--- a/rafttest/interaction_env_handler_campaign.go
+++ b/rafttest/interaction_env_handler_campaign.go
@@ -22,10 +22,10 @@ import (
 
 func (env *InteractionEnv) handleCampaign(t *testing.T, d datadriven.TestData) error {
 	idx := firstAsNodeIdx(t, d)
-	return env.Campaign(t, idx)
+	return env.Campaign(idx)
 }
 
 // Campaign the node at the given index.
-func (env *InteractionEnv) Campaign(t *testing.T, idx int) error {
+func (env *InteractionEnv) Campaign(idx int) error {
 	return env.Nodes[idx].Campaign()
 }

--- a/rafttest/interaction_env_handler_forget_leader.go
+++ b/rafttest/interaction_env_handler_forget_leader.go
@@ -22,11 +22,11 @@ import (
 
 func (env *InteractionEnv) handleForgetLeader(t *testing.T, d datadriven.TestData) error {
 	idx := firstAsNodeIdx(t, d)
-	env.ForgetLeader(t, idx)
+	env.ForgetLeader(idx)
 	return nil
 }
 
 // ForgetLeader makes the follower at the given index forget its leader.
-func (env *InteractionEnv) ForgetLeader(t *testing.T, idx int) {
+func (env *InteractionEnv) ForgetLeader(idx int) {
 	env.Nodes[idx].ForgetLeader()
 }

--- a/rafttest/interaction_env_handler_log_level.go
+++ b/rafttest/interaction_env_handler_log_level.go
@@ -17,12 +17,11 @@ package rafttest
 import (
 	"fmt"
 	"strings"
-	"testing"
 
 	"github.com/cockroachdb/datadriven"
 )
 
-func (env *InteractionEnv) handleLogLevel(t *testing.T, d datadriven.TestData) error {
+func (env *InteractionEnv) handleLogLevel(d datadriven.TestData) error {
 	return env.LogLevel(d.CmdArgs[0].Key)
 }
 

--- a/rawnode_test.go
+++ b/rawnode_test.go
@@ -37,7 +37,7 @@ type rawNodeAdapter struct {
 var _ Node = (*rawNodeAdapter)(nil)
 
 // TransferLeadership is to test when node specifies lead, which is pointless, can just be filled in.
-func (a *rawNodeAdapter) TransferLeadership(ctx context.Context, lead, transferee uint64) {
+func (a *rawNodeAdapter) TransferLeadership(_ context.Context, _, transferee uint64) {
 	a.RawNode.TransferLeader(transferee)
 }
 

--- a/scripts/genproto.sh
+++ b/scripts/genproto.sh
@@ -13,8 +13,8 @@ fi
 
 source ./scripts/test_lib.sh
 
-if [[ $(protoc --version | cut -f2 -d' ') != "3.14.0" ]]; then
-  echo "could not find protoc 3.14.0, is it installed + in PATH?"
+if [[ $(protoc --version | cut -f2 -d' ') != "3.20.3" ]]; then
+  echo "could not find protoc 3.20.3, is it installed + in PATH?"
   exit 255
 fi
 


### PR DESCRIPTION
Maintenance to bump raft to latest go patch `1.19.12` for workflows and stay in sync with etcd-io/etcd versions for `golangci-lint` and `protoc`.

Refer: https://github.com/golang/go/issues?q=milestone%3AGo1.19.12+label%3ACherryPickApproved
