### PR TITLE
Update to golang 1.20 minor release

### DIFF
--- a/.github/workflows/govuln.yaml
+++ b/.github/workflows/govuln.yaml
@@ -7,6 +7,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.19.12"
+          go-version: "1.20.7"
       - run: date
       - run: go install golang.org/x/vuln/cmd/govulncheck@latest && govulncheck ./...

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -7,7 +7,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.19.12"
+          go-version: "1.20.7"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.19.12"
+          go-version: "1.20.7"
       - env:
           TARGET: ${{ matrix.target }}
         run: |

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.etcd.io/raft/v3
 
-go 1.19
+go 1.20
 
 require (
 	github.com/cockroachdb/datadriven v1.0.2

--- a/tools/mod/go.mod
+++ b/tools/mod/go.mod
@@ -1,6 +1,6 @@
 module go.etcd.io/raft/tools/v3
 
-go 1.19
+go 1.20
 
 require (
 	github.com/alexkohler/nakedret v1.0.0


### PR DESCRIPTION
Migrate `main` to golang `1.20`, as `1.19` is now out of support following the release of go `1.21`, refer: https://go.dev/blog/go1.21

Maintenance to keep raft in line with `etcd-io/etcd`.

Last task to close out https://github.com/etcd-io/etcd/issues/16393.