### PR TITLE
Added OWNERS file for raft

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,12 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - ahrtr           # Benjamin Wang <wachao@vmware.com> <benjamin.ahrtr@gmail.com>
+  - mitake          # Hitoshi Mitake <h.mitake@gmail.com>
+  - serathius       # Marek Siarkowicz <siarkowicz@google.com> <marek.siarkowicz@gmail.com>
+  - ptabor          # Piotr Tabor <piotr.tabor@gmail.com>
+  - spzala          # Sahdev Zala <spzala@us.ibm.com>
+reviewers:
+  - pavelkalinnikov # Pavel Kalinnikov <pavel@cockroachlabs.com>
+emeritus_approvers:
+  - tbg             # Tobias Grieger <tobias.b.grieger@gmail.com>


### PR DESCRIPTION
This pull request proposes a layout for the OWNERS file we need to add to each non archived subproject under the etcd-io github organisation as part of the creation of sig-etcd.

Refer to OWNERS documentation: https://www.kubernetes.dev/docs/guide/owners

Note: Once the sig comes online fully and we shift to managing org membership through the kubernetes org bot then we need to consider a follow-up pull request to prune out the old MAINTAINERS file approach.