### PR TITLE
chore: Rename prs to trk

### DIFF
--- a/confchange/datadriven_test.go
+++ b/confchange/datadriven_test.go
@@ -80,22 +80,22 @@ func TestConfChangeDataDriven(t *testing.T) {
 			}
 
 			var cfg tracker.Config
-			var prs tracker.ProgressMap
+			var trk tracker.ProgressMap
 			var err error
 			switch d.Cmd {
 			case "simple":
-				cfg, prs, err = c.Simple(ccs...)
+				cfg, trk, err = c.Simple(ccs...)
 			case "enter-joint":
 				var autoLeave bool
 				if len(d.CmdArgs) > 0 {
 					d.ScanArgs(t, "autoleave", &autoLeave)
 				}
-				cfg, prs, err = c.EnterJoint(autoLeave, ccs...)
+				cfg, trk, err = c.EnterJoint(autoLeave, ccs...)
 			case "leave-joint":
 				if len(ccs) > 0 {
 					err = errors.New("this command takes no input")
 				} else {
-					cfg, prs, err = c.LeaveJoint()
+					cfg, trk, err = c.LeaveJoint()
 				}
 			default:
 				return "unknown command"
@@ -103,7 +103,7 @@ func TestConfChangeDataDriven(t *testing.T) {
 			if err != nil {
 				return err.Error() + "\n"
 			}
-			c.Tracker.Config, c.Tracker.Progress = cfg, prs
+			c.Tracker.Config, c.Tracker.Progress = cfg, trk
 			return fmt.Sprintf("%s\n%s", c.Tracker.Config, c.Tracker.Progress)
 		})
 	})

--- a/confchange/quick_test.go
+++ b/confchange/quick_test.go
@@ -37,50 +37,50 @@ func TestConfChangeQuick(t *testing.T) {
 	const infoCount = 5
 
 	runWithJoint := func(c *Changer, ccs []pb.ConfChangeSingle) error {
-		cfg, prs, err := c.EnterJoint(false /* autoLeave */, ccs...)
+		cfg, trk, err := c.EnterJoint(false /* autoLeave */, ccs...)
 		if err != nil {
 			return err
 		}
 		// Also do this with autoLeave on, just to check that we'd get the same
 		// result.
-		cfg2a, prs2a, err := c.EnterJoint(true /* autoLeave */, ccs...)
+		cfg2a, trk2a, err := c.EnterJoint(true /* autoLeave */, ccs...)
 		if err != nil {
 			return err
 		}
 		cfg2a.AutoLeave = false
-		if !reflect.DeepEqual(cfg, cfg2a) || !reflect.DeepEqual(prs, prs2a) {
-			return fmt.Errorf("cfg: %+v\ncfg2a: %+v\nprs: %+v\nprs2a: %+v",
-				cfg, cfg2a, prs, prs2a)
+		if !reflect.DeepEqual(cfg, cfg2a) || !reflect.DeepEqual(trk, trk2a) {
+			return fmt.Errorf("cfg: %+v\ncfg2a: %+v\ntrk: %+v\ntrk2a: %+v",
+				cfg, cfg2a, trk, trk2a)
 		}
 		c.Tracker.Config = cfg
-		c.Tracker.Progress = prs
-		cfg2b, prs2b, err := c.LeaveJoint()
+		c.Tracker.Progress = trk
+		cfg2b, trk2b, err := c.LeaveJoint()
 		if err != nil {
 			return err
 		}
 		// Reset back to the main branch with autoLeave=false.
 		c.Tracker.Config = cfg
-		c.Tracker.Progress = prs
-		cfg, prs, err = c.LeaveJoint()
+		c.Tracker.Progress = trk
+		cfg, trk, err = c.LeaveJoint()
 		if err != nil {
 			return err
 		}
-		if !reflect.DeepEqual(cfg, cfg2b) || !reflect.DeepEqual(prs, prs2b) {
-			return fmt.Errorf("cfg: %+v\ncfg2b: %+v\nprs: %+v\nprs2b: %+v",
-				cfg, cfg2b, prs, prs2b)
+		if !reflect.DeepEqual(cfg, cfg2b) || !reflect.DeepEqual(trk, trk2b) {
+			return fmt.Errorf("cfg: %+v\ncfg2b: %+v\ntrk: %+v\ntrk2b: %+v",
+				cfg, cfg2b, trk, trk2b)
 		}
 		c.Tracker.Config = cfg
-		c.Tracker.Progress = prs
+		c.Tracker.Progress = trk
 		return nil
 	}
 
 	runWithSimple := func(c *Changer, ccs []pb.ConfChangeSingle) error {
 		for _, cc := range ccs {
-			cfg, prs, err := c.Simple(cc)
+			cfg, trk, err := c.Simple(cc)
 			if err != nil {
 				return err
 			}
-			c.Tracker.Config, c.Tracker.Progress = cfg, prs
+			c.Tracker.Config, c.Tracker.Progress = cfg, trk
 		}
 		return nil
 	}

--- a/confchange/restore.go
+++ b/confchange/restore.go
@@ -98,12 +98,12 @@ func toConfChangeSingle(cs pb.ConfState) (out []pb.ConfChangeSingle, in []pb.Con
 
 func chain(chg Changer, ops ...func(Changer) (tracker.Config, tracker.ProgressMap, error)) (tracker.Config, tracker.ProgressMap, error) {
 	for _, op := range ops {
-		cfg, prs, err := op(chg)
+		cfg, trk, err := op(chg)
 		if err != nil {
 			return tracker.Config{}, nil, err
 		}
 		chg.Tracker.Config = cfg
-		chg.Tracker.Progress = prs
+		chg.Tracker.Progress = trk
 	}
 	return chg.Tracker.Config, chg.Tracker.Progress, nil
 }

--- a/confchange/restore_test.go
+++ b/confchange/restore_test.go
@@ -89,13 +89,13 @@ func TestRestore(t *testing.T) {
 			Tracker:   tracker.MakeProgressTracker(20, 0),
 			LastIndex: 10,
 		}
-		cfg, prs, err := Restore(chg, cs)
+		cfg, trk, err := Restore(chg, cs)
 		if err != nil {
 			t.Error(err)
 			return false
 		}
 		chg.Tracker.Config = cfg
-		chg.Tracker.Progress = prs
+		chg.Tracker.Progress = trk
 
 		for _, sl := range [][]uint64{
 			cs.Voters,

--- a/node.go
+++ b/node.go
@@ -392,13 +392,13 @@ func (n *node) run() {
 				close(pm.result)
 			}
 		case m := <-n.recvc:
-			if IsResponseMsg(m.Type) && !IsLocalMsgTarget(m.From) && r.prs.Progress[m.From] == nil {
+			if IsResponseMsg(m.Type) && !IsLocalMsgTarget(m.From) && r.trk.Progress[m.From] == nil {
 				// Filter out response message from unknown From.
 				break
 			}
 			r.Step(m)
 		case cc := <-n.confc:
-			_, okBefore := r.prs.Progress[r.id]
+			_, okBefore := r.trk.Progress[r.id]
 			cs := r.applyConfChange(cc)
 			// If the node was removed, block incoming proposals. Note that we
 			// only do this if the node was in the config before. Nodes may be
@@ -409,7 +409,7 @@ func (n *node) run() {
 			// NB: propc is reset when the leader changes, which, if we learn
 			// about it, sort of implies that we got readded, maybe? This isn't
 			// very sound and likely has bugs.
-			if _, okAfter := r.prs.Progress[r.id]; okBefore && !okAfter {
+			if _, okAfter := r.trk.Progress[r.id]; okBefore && !okAfter {
 				var found bool
 				for _, sl := range [][]uint64{cs.Voters, cs.VotersOutgoing} {
 					for _, id := range sl {

--- a/raft_flow_control_test.go
+++ b/raft_flow_control_test.go
@@ -29,11 +29,11 @@ func TestMsgAppFlowControlFull(t *testing.T) {
 	r.becomeCandidate()
 	r.becomeLeader()
 
-	pr2 := r.prs.Progress[2]
+	pr2 := r.trk.Progress[2]
 	// force the progress to be in replicate state
 	pr2.BecomeReplicate()
 	// fill in the inflights window
-	for i := 0; i < r.prs.MaxInflight; i++ {
+	for i := 0; i < r.trk.MaxInflight; i++ {
 		r.Step(pb.Message{From: 1, To: 1, Type: pb.MsgProp, Entries: []pb.Entry{{Data: []byte("somedata")}}})
 		ms := r.readMessages()
 		if len(ms) != 1 || ms[0].Type != pb.MsgApp {
@@ -65,18 +65,18 @@ func TestMsgAppFlowControlMoveForward(t *testing.T) {
 	r.becomeCandidate()
 	r.becomeLeader()
 
-	pr2 := r.prs.Progress[2]
+	pr2 := r.trk.Progress[2]
 	// force the progress to be in replicate state
 	pr2.BecomeReplicate()
 	// fill in the inflights window
-	for i := 0; i < r.prs.MaxInflight; i++ {
+	for i := 0; i < r.trk.MaxInflight; i++ {
 		r.Step(pb.Message{From: 1, To: 1, Type: pb.MsgProp, Entries: []pb.Entry{{Data: []byte("somedata")}}})
 		r.readMessages()
 	}
 
 	// 1 is noop, 2 is the first proposal we just sent.
 	// so we start with 2.
-	for tt := 2; tt < r.prs.MaxInflight; tt++ {
+	for tt := 2; tt < r.trk.MaxInflight; tt++ {
 		// move forward the window
 		r.Step(pb.Message{From: 2, To: 1, Type: pb.MsgAppResp, Index: uint64(tt)})
 		r.readMessages()
@@ -110,11 +110,11 @@ func TestMsgAppFlowControlRecvHeartbeat(t *testing.T) {
 	r.becomeCandidate()
 	r.becomeLeader()
 
-	pr2 := r.prs.Progress[2]
+	pr2 := r.trk.Progress[2]
 	// force the progress to be in replicate state
 	pr2.BecomeReplicate()
 	// fill in the inflights window
-	for i := 0; i < r.prs.MaxInflight; i++ {
+	for i := 0; i < r.trk.MaxInflight; i++ {
 		r.Step(pb.Message{From: 1, To: 1, Type: pb.MsgProp, Entries: []pb.Entry{{Data: []byte("somedata")}}})
 		r.readMessages()
 	}

--- a/raft_paper_test.go
+++ b/raft_paper_test.go
@@ -170,7 +170,7 @@ func testNonleaderStartElection(t *testing.T, state StateType) {
 	if r.state != StateCandidate {
 		t.Errorf("state = %s, want %s", r.state, StateCandidate)
 	}
-	if !r.prs.Votes[r.id] {
+	if !r.trk.Votes[r.id] {
 		t.Errorf("vote for self = false, want true")
 	}
 	msgs := r.readMessages()

--- a/raft_snap_test.go
+++ b/raft_snap_test.go
@@ -40,11 +40,11 @@ func TestSendingSnapshotSetPendingSnapshot(t *testing.T) {
 
 	// force set the next of node 2, so that
 	// node 2 needs a snapshot
-	sm.prs.Progress[2].Next = sm.raftLog.firstIndex()
+	sm.trk.Progress[2].Next = sm.raftLog.firstIndex()
 
-	sm.Step(pb.Message{From: 2, To: 1, Type: pb.MsgAppResp, Index: sm.prs.Progress[2].Next - 1, Reject: true})
-	if sm.prs.Progress[2].PendingSnapshot != 11 {
-		t.Fatalf("PendingSnapshot = %d, want 11", sm.prs.Progress[2].PendingSnapshot)
+	sm.Step(pb.Message{From: 2, To: 1, Type: pb.MsgAppResp, Index: sm.trk.Progress[2].Next - 1, Reject: true})
+	if sm.trk.Progress[2].PendingSnapshot != 11 {
+		t.Fatalf("PendingSnapshot = %d, want 11", sm.trk.Progress[2].PendingSnapshot)
 	}
 }
 
@@ -56,7 +56,7 @@ func TestPendingSnapshotPauseReplication(t *testing.T) {
 	sm.becomeCandidate()
 	sm.becomeLeader()
 
-	sm.prs.Progress[2].BecomeSnapshot(11)
+	sm.trk.Progress[2].BecomeSnapshot(11)
 
 	sm.Step(pb.Message{From: 1, To: 1, Type: pb.MsgProp, Entries: []pb.Entry{{Data: []byte("somedata")}}})
 	msgs := sm.readMessages()
@@ -73,18 +73,18 @@ func TestSnapshotFailure(t *testing.T) {
 	sm.becomeCandidate()
 	sm.becomeLeader()
 
-	sm.prs.Progress[2].Next = 1
-	sm.prs.Progress[2].BecomeSnapshot(11)
+	sm.trk.Progress[2].Next = 1
+	sm.trk.Progress[2].BecomeSnapshot(11)
 
 	sm.Step(pb.Message{From: 2, To: 1, Type: pb.MsgSnapStatus, Reject: true})
-	if sm.prs.Progress[2].PendingSnapshot != 0 {
-		t.Fatalf("PendingSnapshot = %d, want 0", sm.prs.Progress[2].PendingSnapshot)
+	if sm.trk.Progress[2].PendingSnapshot != 0 {
+		t.Fatalf("PendingSnapshot = %d, want 0", sm.trk.Progress[2].PendingSnapshot)
 	}
-	if sm.prs.Progress[2].Next != 1 {
-		t.Fatalf("Next = %d, want 1", sm.prs.Progress[2].Next)
+	if sm.trk.Progress[2].Next != 1 {
+		t.Fatalf("Next = %d, want 1", sm.trk.Progress[2].Next)
 	}
-	if !sm.prs.Progress[2].MsgAppFlowPaused {
-		t.Errorf("MsgAppFlowPaused = %v, want true", sm.prs.Progress[2].MsgAppFlowPaused)
+	if !sm.trk.Progress[2].MsgAppFlowPaused {
+		t.Errorf("MsgAppFlowPaused = %v, want true", sm.trk.Progress[2].MsgAppFlowPaused)
 	}
 }
 
@@ -96,18 +96,18 @@ func TestSnapshotSucceed(t *testing.T) {
 	sm.becomeCandidate()
 	sm.becomeLeader()
 
-	sm.prs.Progress[2].Next = 1
-	sm.prs.Progress[2].BecomeSnapshot(11)
+	sm.trk.Progress[2].Next = 1
+	sm.trk.Progress[2].BecomeSnapshot(11)
 
 	sm.Step(pb.Message{From: 2, To: 1, Type: pb.MsgSnapStatus, Reject: false})
-	if sm.prs.Progress[2].PendingSnapshot != 0 {
-		t.Fatalf("PendingSnapshot = %d, want 0", sm.prs.Progress[2].PendingSnapshot)
+	if sm.trk.Progress[2].PendingSnapshot != 0 {
+		t.Fatalf("PendingSnapshot = %d, want 0", sm.trk.Progress[2].PendingSnapshot)
 	}
-	if sm.prs.Progress[2].Next != 12 {
-		t.Fatalf("Next = %d, want 12", sm.prs.Progress[2].Next)
+	if sm.trk.Progress[2].Next != 12 {
+		t.Fatalf("Next = %d, want 12", sm.trk.Progress[2].Next)
 	}
-	if !sm.prs.Progress[2].MsgAppFlowPaused {
-		t.Errorf("MsgAppFlowPaused = %v, want true", sm.prs.Progress[2].MsgAppFlowPaused)
+	if !sm.trk.Progress[2].MsgAppFlowPaused {
+		t.Errorf("MsgAppFlowPaused = %v, want true", sm.trk.Progress[2].MsgAppFlowPaused)
 	}
 }
 
@@ -119,23 +119,23 @@ func TestSnapshotAbort(t *testing.T) {
 	sm.becomeCandidate()
 	sm.becomeLeader()
 
-	sm.prs.Progress[2].Next = 1
-	sm.prs.Progress[2].BecomeSnapshot(11)
+	sm.trk.Progress[2].Next = 1
+	sm.trk.Progress[2].BecomeSnapshot(11)
 
 	// A successful msgAppResp that has a higher/equal index than the
 	// pending snapshot should abort the pending snapshot.
 	sm.Step(pb.Message{From: 2, To: 1, Type: pb.MsgAppResp, Index: 11})
-	if sm.prs.Progress[2].PendingSnapshot != 0 {
-		t.Fatalf("PendingSnapshot = %d, want 0", sm.prs.Progress[2].PendingSnapshot)
+	if sm.trk.Progress[2].PendingSnapshot != 0 {
+		t.Fatalf("PendingSnapshot = %d, want 0", sm.trk.Progress[2].PendingSnapshot)
 	}
 	// The follower entered StateReplicate and the leader send an append
 	// and optimistically updated the progress (so we see 13 instead of 12).
 	// There is something to append because the leader appended an empty entry
 	// to the log at index 12 when it assumed leadership.
-	if sm.prs.Progress[2].Next != 13 {
-		t.Fatalf("Next = %d, want 13", sm.prs.Progress[2].Next)
+	if sm.trk.Progress[2].Next != 13 {
+		t.Fatalf("Next = %d, want 13", sm.trk.Progress[2].Next)
 	}
-	if n := sm.prs.Progress[2].Inflights.Count(); n != 1 {
+	if n := sm.trk.Progress[2].Inflights.Count(); n != 1 {
 		t.Fatalf("expected an inflight message, got %d", n)
 	}
 }

--- a/rawnode.go
+++ b/rawnode.go
@@ -25,7 +25,7 @@ import (
 var ErrStepLocalMsg = errors.New("raft: cannot step raft local message")
 
 // ErrStepPeerNotFound is returned when try to step a response message
-// but there is no peer found in raft.prs for that node.
+// but there is no peer found in raft.trk for that node.
 var ErrStepPeerNotFound = errors.New("raft: cannot step as peer not found")
 
 // RawNode is a thread-unsafe Node.
@@ -120,7 +120,7 @@ func (rn *RawNode) Step(m pb.Message) error {
 	if IsLocalMsg(m.Type) && !IsLocalMsgTarget(m.From) {
 		return ErrStepLocalMsg
 	}
-	if IsResponseMsg(m.Type) && !IsLocalMsgTarget(m.From) && rn.raft.prs.Progress[m.From] == nil {
+	if IsResponseMsg(m.Type) && !IsLocalMsgTarget(m.From) && rn.raft.trk.Progress[m.From] == nil {
 		return ErrStepPeerNotFound
 	}
 	return rn.raft.Step(m)
@@ -516,7 +516,7 @@ const (
 // WithProgress is a helper to introspect the Progress for this node and its
 // peers.
 func (rn *RawNode) WithProgress(visitor func(id uint64, typ ProgressType, pr tracker.Progress)) {
-	rn.raft.prs.Visit(func(id uint64, pr *tracker.Progress) {
+	rn.raft.trk.Visit(func(id uint64, pr *tracker.Progress) {
 		typ := ProgressTypePeer
 		if pr.IsLearner {
 			typ = ProgressTypeLearner

--- a/rawnode_test.go
+++ b/rawnode_test.go
@@ -883,7 +883,7 @@ func TestRawNodeStatus(t *testing.T) {
 	if status.RaftState != StateLeader {
 		t.Fatal("not leader")
 	}
-	if exp, act := *rn.raft.prs.Progress[1], status.Progress[1]; !reflect.DeepEqual(exp, act) {
+	if exp, act := *rn.raft.trk.Progress[1], status.Progress[1]; !reflect.DeepEqual(exp, act) {
 		t.Fatalf("want: %+v\ngot:  %+v", exp, act)
 	}
 	expCfg := tracker.Config{Voters: quorum.JointConfig{

--- a/status.go
+++ b/status.go
@@ -43,7 +43,7 @@ type BasicStatus struct {
 
 func getProgressCopy(r *raft) map[uint64]tracker.Progress {
 	m := make(map[uint64]tracker.Progress)
-	r.prs.Visit(func(id uint64, pr *tracker.Progress) {
+	r.trk.Visit(func(id uint64, pr *tracker.Progress) {
 		p := *pr
 		p.Inflights = pr.Inflights.Clone()
 		pr = nil
@@ -71,7 +71,7 @@ func getStatus(r *raft) Status {
 	if s.RaftState == StateLeader {
 		s.Progress = getProgressCopy(r)
 	}
-	s.Config = r.prs.Config.Clone()
+	s.Config = r.trk.Config.Clone()
 	return s
 }
 


### PR DESCRIPTION
Performed the following steps.

  - replace `prs` with `trk`
    ```shell
    ./ -name '*.go' -type f -print0 | xargs -0 sed -i -e "s/prs/trk/g"
    git restore tracker/state.go
    ```
  - delete TODO comment
    ```shell
    // TODO(tbg): rename to trk.
    ```
    see: https://github.com/etcd-io/raft/pull/114/files#diff-d7ffa919352e4a9c13fdb7b7fe6fa5302de94a745b90ae80155605e995ef5f11L351