### PR TITLE
remove unused min and max funcs

### DIFF
--- a/tracker/progress.go
+++ b/tracker/progress.go
@@ -106,20 +106,6 @@ func (pr *Progress) ResetState(state StateType) {
 	pr.Inflights.reset()
 }
 
-func max(a, b uint64) uint64 {
-	if a > b {
-		return a
-	}
-	return b
-}
-
-func min(a, b uint64) uint64 {
-	if a > b {
-		return b
-	}
-	return a
-}
-
 // BecomeProbe transitions into StateProbe. Next is reset to Match+1 or,
 // optionally and if larger, the index of the pending snapshot.
 func (pr *Progress) BecomeProbe() {

--- a/util.go
+++ b/util.go
@@ -26,20 +26,6 @@ func (st StateType) MarshalJSON() ([]byte, error) {
 	return []byte(fmt.Sprintf("%q", st.String())), nil
 }
 
-func min(a, b uint64) uint64 {
-	if a > b {
-		return b
-	}
-	return a
-}
-
-func max(a, b uint64) uint64 {
-	if a > b {
-		return a
-	}
-	return b
-}
-
 var isLocalMsg = [...]bool{
 	pb.MsgHup:               true,
 	pb.MsgBeat:              true,


### PR DESCRIPTION
Go has min/max built-ins since 1.21.
https://tip.golang.org/doc/go1.21#language