### PR TITLE
log: fixup raftLog initialization

### DIFF
--- a/log.go
+++ b/log.go
@@ -16,7 +16,6 @@ package raft
 
 import (
 	"fmt"
-	"log"
 
 	pb "go.etcd.io/raft/v3/raftpb"
 )
@@ -72,9 +71,6 @@ func newLog(storage Storage, logger Logger) *raftLog {
 // newLogWithSize returns a log using the given storage and max
 // message size.
 func newLogWithSize(storage Storage, logger Logger, maxApplyingEntsSize entryEncodingSize) *raftLog {
-	if storage == nil {
-		log.Panic("storage must not be nil")
-	}
 	firstIndex, err := storage.FirstIndex()
 	if err != nil {
 		panic(err) // TODO(bdarnell)


### PR DESCRIPTION
This PR consolidates the `raftLog` struct initialization into a single return statement. It also makes all unit-tests use the `newLog` constructor function to initialize a log, instead of populating the struct manually.

Changes to the `unstable` / `raftLog` structures should by default not require fixing boilerplate in tests.

Related to #146
Blocks #139