### PR TITLE
tracker: track in-flight commit index

### DIFF
--- a/raft.go
+++ b/raft.go
@@ -644,7 +644,7 @@ func (r *raft) maybeSendAppend(to uint64, sendIfEmpty bool) bool {
 		Entries: ents,
 		Commit:  r.raftLog.committed,
 	})
-	pr.UpdateOnEntriesSend(len(ents), uint64(payloadsSize(ents)))
+	pr.SentEntries(len(ents), uint64(payloadsSize(ents)))
 	pr.SentCommit(r.raftLog.committed)
 	return true
 }

--- a/testdata/confchange_v1_add_single.txt
+++ b/testdata/confchange_v1_add_single.txt
@@ -94,15 +94,3 @@ stabilize
 > 1 receiving messages
   2->1 MsgAppResp Term:1 Log:0/4
   DEBUG 1 recovered from needing snapshot, resumed sending replication messages to 2 [StateSnapshot match=4 next=5 paused pendingSnap=4]
-> 1 handling Ready
-  Ready MustSync=false:
-  Messages:
-  1->2 MsgApp Term:1 Log:1/4 Commit:4
-> 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/4 Commit:4
-> 2 handling Ready
-  Ready MustSync=false:
-  Messages:
-  2->1 MsgAppResp Term:1 Log:0/4
-> 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/4

--- a/testdata/confchange_v1_add_single.txt
+++ b/testdata/confchange_v1_add_single.txt
@@ -72,7 +72,7 @@ stabilize
   DEBUG 1 received MsgAppResp(rejected, hint: (index 0, term 0)) from 2 for index 3
   DEBUG 1 decreased progress of 2 to [StateProbe match=0 next=1]
   DEBUG 1 [firstindex: 3, commit: 4] sent snapshot[index: 4, term: 1] to 2 [StateProbe match=0 next=1]
-  DEBUG 1 paused sending replication messages to 2 [StateSnapshot match=0 next=1 paused pendingSnap=4]
+  DEBUG 1 paused sending replication messages to 2 [StateSnapshot match=0 next=5 paused pendingSnap=4]
 > 1 handling Ready
   Ready MustSync=false:
   Messages:

--- a/testdata/confchange_v2_add_double_auto.txt
+++ b/testdata/confchange_v2_add_double_auto.txt
@@ -193,18 +193,6 @@ stabilize 1 3
 > 1 receiving messages
   3->1 MsgAppResp Term:1 Log:0/5
   DEBUG 1 recovered from needing snapshot, resumed sending replication messages to 3 [StateSnapshot match=5 next=6 paused pendingSnap=5]
-> 1 handling Ready
-  Ready MustSync=false:
-  Messages:
-  1->3 MsgApp Term:1 Log:1/5 Commit:5
-> 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/5 Commit:5
-> 3 handling Ready
-  Ready MustSync=false:
-  Messages:
-  3->1 MsgAppResp Term:1 Log:0/5
-> 1 receiving messages
-  3->1 MsgAppResp Term:1 Log:0/5
 
 # Nothing else happens.
 stabilize

--- a/testdata/confchange_v2_add_double_auto.txt
+++ b/testdata/confchange_v2_add_double_auto.txt
@@ -95,7 +95,7 @@ stabilize 1 2
   DEBUG 1 received MsgAppResp(rejected, hint: (index 0, term 0)) from 2 for index 3
   DEBUG 1 decreased progress of 2 to [StateProbe match=0 next=1]
   DEBUG 1 [firstindex: 3, commit: 4] sent snapshot[index: 4, term: 1] to 2 [StateProbe match=0 next=1]
-  DEBUG 1 paused sending replication messages to 2 [StateSnapshot match=0 next=1 paused pendingSnap=4]
+  DEBUG 1 paused sending replication messages to 2 [StateSnapshot match=0 next=5 paused pendingSnap=4]
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
@@ -171,7 +171,7 @@ stabilize 1 3
   DEBUG 1 received MsgAppResp(rejected, hint: (index 0, term 0)) from 3 for index 3
   DEBUG 1 decreased progress of 3 to [StateProbe match=0 next=1]
   DEBUG 1 [firstindex: 3, commit: 5] sent snapshot[index: 5, term: 1] to 3 [StateProbe match=0 next=1]
-  DEBUG 1 paused sending replication messages to 3 [StateSnapshot match=0 next=1 paused pendingSnap=5]
+  DEBUG 1 paused sending replication messages to 3 [StateSnapshot match=0 next=6 paused pendingSnap=5]
 > 1 handling Ready
   Ready MustSync=false:
   Messages:

--- a/testdata/confchange_v2_add_double_implicit.txt
+++ b/testdata/confchange_v2_add_double_implicit.txt
@@ -78,7 +78,7 @@ stabilize 1 2
   DEBUG 1 received MsgAppResp(rejected, hint: (index 0, term 0)) from 2 for index 3
   DEBUG 1 decreased progress of 2 to [StateProbe match=0 next=1]
   DEBUG 1 [firstindex: 3, commit: 4] sent snapshot[index: 4, term: 1] to 2 [StateProbe match=0 next=1]
-  DEBUG 1 paused sending replication messages to 2 [StateSnapshot match=0 next=1 paused pendingSnap=4]
+  DEBUG 1 paused sending replication messages to 2 [StateSnapshot match=0 next=5 paused pendingSnap=4]
 > 1 handling Ready
   Ready MustSync=false:
   Messages:

--- a/testdata/confchange_v2_add_single_auto.txt
+++ b/testdata/confchange_v2_add_single_auto.txt
@@ -73,7 +73,7 @@ stabilize
   DEBUG 1 received MsgAppResp(rejected, hint: (index 0, term 0)) from 2 for index 3
   DEBUG 1 decreased progress of 2 to [StateProbe match=0 next=1]
   DEBUG 1 [firstindex: 3, commit: 4] sent snapshot[index: 4, term: 1] to 2 [StateProbe match=0 next=1]
-  DEBUG 1 paused sending replication messages to 2 [StateSnapshot match=0 next=1 paused pendingSnap=4]
+  DEBUG 1 paused sending replication messages to 2 [StateSnapshot match=0 next=5 paused pendingSnap=4]
 > 1 handling Ready
   Ready MustSync=false:
   Messages:

--- a/testdata/confchange_v2_add_single_auto.txt
+++ b/testdata/confchange_v2_add_single_auto.txt
@@ -95,15 +95,3 @@ stabilize
 > 1 receiving messages
   2->1 MsgAppResp Term:1 Log:0/4
   DEBUG 1 recovered from needing snapshot, resumed sending replication messages to 2 [StateSnapshot match=4 next=5 paused pendingSnap=4]
-> 1 handling Ready
-  Ready MustSync=false:
-  Messages:
-  1->2 MsgApp Term:1 Log:1/4 Commit:4
-> 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/4 Commit:4
-> 2 handling Ready
-  Ready MustSync=false:
-  Messages:
-  2->1 MsgAppResp Term:1 Log:0/4
-> 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/4

--- a/testdata/confchange_v2_add_single_explicit.txt
+++ b/testdata/confchange_v2_add_single_explicit.txt
@@ -95,18 +95,6 @@ stabilize 1 2
 > 1 receiving messages
   2->1 MsgAppResp Term:1 Log:0/4
   DEBUG 1 recovered from needing snapshot, resumed sending replication messages to 2 [StateSnapshot match=4 next=5 paused pendingSnap=4]
-> 1 handling Ready
-  Ready MustSync=false:
-  Messages:
-  1->2 MsgApp Term:1 Log:1/4 Commit:4
-> 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/4 Commit:4
-> 2 handling Ready
-  Ready MustSync=false:
-  Messages:
-  2->1 MsgAppResp Term:1 Log:0/4
-> 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/4
 
 # Check that we're not allowed to change membership again while in the joint state.
 # This leads to an empty entry being proposed instead (index 5 in the stabilize block

--- a/testdata/confchange_v2_add_single_explicit.txt
+++ b/testdata/confchange_v2_add_single_explicit.txt
@@ -73,7 +73,7 @@ stabilize 1 2
   DEBUG 1 received MsgAppResp(rejected, hint: (index 0, term 0)) from 2 for index 3
   DEBUG 1 decreased progress of 2 to [StateProbe match=0 next=1]
   DEBUG 1 [firstindex: 3, commit: 4] sent snapshot[index: 4, term: 1] to 2 [StateProbe match=0 next=1]
-  DEBUG 1 paused sending replication messages to 2 [StateSnapshot match=0 next=1 paused pendingSnap=4]
+  DEBUG 1 paused sending replication messages to 2 [StateSnapshot match=0 next=5 paused pendingSnap=4]
 > 1 handling Ready
   Ready MustSync=false:
   Messages:

--- a/testdata/confchange_v2_replace_leader.txt
+++ b/testdata/confchange_v2_replace_leader.txt
@@ -143,18 +143,6 @@ stabilize
   4->1 MsgAppResp Term:1 Log:0/4
 > 1 receiving messages
   4->1 MsgAppResp Term:1 Log:0/4
-> 1 handling Ready
-  Ready MustSync=false:
-  Messages:
-  1->4 MsgApp Term:1 Log:1/4 Commit:4
-> 4 receiving messages
-  1->4 MsgApp Term:1 Log:1/4 Commit:4
-> 4 handling Ready
-  Ready MustSync=false:
-  Messages:
-  4->1 MsgAppResp Term:1 Log:0/4
-> 1 receiving messages
-  4->1 MsgAppResp Term:1 Log:0/4
 
 
 # Transfer leadership while in the joint config.
@@ -284,12 +272,10 @@ stabilize
   CommittedEntries:
   2/5 EntryNormal ""
   Messages:
-  4->1 MsgApp Term:2 Log:2/5 Commit:4
   4->1 MsgApp Term:2 Log:2/5 Commit:5
   4->2 MsgApp Term:2 Log:2/5 Commit:5
   4->3 MsgApp Term:2 Log:2/5 Commit:5
 > 1 receiving messages
-  4->1 MsgApp Term:2 Log:2/5 Commit:4
   4->1 MsgApp Term:2 Log:2/5 Commit:5
 > 2 receiving messages
   4->2 MsgApp Term:2 Log:2/5 Commit:5
@@ -301,7 +287,6 @@ stabilize
   CommittedEntries:
   2/5 EntryNormal ""
   Messages:
-  1->4 MsgAppResp Term:2 Log:0/5
   1->4 MsgAppResp Term:2 Log:0/5
 > 2 handling Ready
   Ready MustSync=false:
@@ -318,7 +303,6 @@ stabilize
   Messages:
   3->4 MsgAppResp Term:2 Log:0/5
 > 4 receiving messages
-  1->4 MsgAppResp Term:2 Log:0/5
   1->4 MsgAppResp Term:2 Log:0/5
   2->4 MsgAppResp Term:2 Log:0/5
   3->4 MsgAppResp Term:2 Log:0/5

--- a/testdata/probe_and_replicate.txt
+++ b/testdata/probe_and_replicate.txt
@@ -513,18 +513,6 @@ stabilize 1 2
   2->1 MsgAppResp Term:8 Log:0/21
 > 1 receiving messages
   2->1 MsgAppResp Term:8 Log:0/21
-> 1 handling Ready
-  Ready MustSync=false:
-  Messages:
-  1->2 MsgApp Term:8 Log:8/21 Commit:18
-> 2 receiving messages
-  1->2 MsgApp Term:8 Log:8/21 Commit:18
-> 2 handling Ready
-  Ready MustSync=false:
-  Messages:
-  2->1 MsgAppResp Term:8 Log:0/21
-> 1 receiving messages
-  2->1 MsgAppResp Term:8 Log:0/21
 
 stabilize 1 3
 ----
@@ -575,18 +563,6 @@ stabilize 1 3
   5/16 EntryNormal ""
   5/17 EntryNormal "prop_5_17"
   6/18 EntryNormal ""
-  Messages:
-  3->1 MsgAppResp Term:8 Log:0/21
-> 1 receiving messages
-  3->1 MsgAppResp Term:8 Log:0/21
-> 1 handling Ready
-  Ready MustSync=false:
-  Messages:
-  1->3 MsgApp Term:8 Log:8/21 Commit:18
-> 3 receiving messages
-  1->3 MsgApp Term:8 Log:8/21 Commit:18
-> 3 handling Ready
-  Ready MustSync=false:
   Messages:
   3->1 MsgAppResp Term:8 Log:0/21
 > 1 receiving messages
@@ -674,18 +650,6 @@ stabilize 1 5
   5->1 MsgAppResp Term:8 Log:0/21
 > 1 receiving messages
   5->1 MsgAppResp Term:8 Log:0/21
-> 1 handling Ready
-  Ready MustSync=false:
-  Messages:
-  1->5 MsgApp Term:8 Log:8/21 Commit:21
-> 5 receiving messages
-  1->5 MsgApp Term:8 Log:8/21 Commit:21
-> 5 handling Ready
-  Ready MustSync=false:
-  Messages:
-  5->1 MsgAppResp Term:8 Log:0/21
-> 1 receiving messages
-  5->1 MsgAppResp Term:8 Log:0/21
 
 stabilize 1 6
 ----
@@ -737,18 +701,6 @@ stabilize 1 6
   6/19 EntryNormal "prop_6_19"
   6/20 EntryNormal "prop_6_20"
   8/21 EntryNormal ""
-  Messages:
-  6->1 MsgAppResp Term:8 Log:0/21
-> 1 receiving messages
-  6->1 MsgAppResp Term:8 Log:0/21
-> 1 handling Ready
-  Ready MustSync=false:
-  Messages:
-  1->6 MsgApp Term:8 Log:8/21 Commit:21
-> 6 receiving messages
-  1->6 MsgApp Term:8 Log:8/21 Commit:21
-> 6 handling Ready
-  Ready MustSync=false:
   Messages:
   6->1 MsgAppResp Term:8 Log:0/21
 > 1 receiving messages
@@ -812,18 +764,6 @@ stabilize 1 7
   6/19 EntryNormal "prop_6_19"
   6/20 EntryNormal "prop_6_20"
   8/21 EntryNormal ""
-  Messages:
-  7->1 MsgAppResp Term:8 Log:0/21
-> 1 receiving messages
-  7->1 MsgAppResp Term:8 Log:0/21
-> 1 handling Ready
-  Ready MustSync=false:
-  Messages:
-  1->7 MsgApp Term:8 Log:8/21 Commit:21
-> 7 receiving messages
-  1->7 MsgApp Term:8 Log:8/21 Commit:21
-> 7 handling Ready
-  Ready MustSync=false:
   Messages:
   7->1 MsgAppResp Term:8 Log:0/21
 > 1 receiving messages

--- a/testdata/snapshot_succeed_via_app_resp.txt
+++ b/testdata/snapshot_succeed_via_app_resp.txt
@@ -87,7 +87,7 @@ stabilize 1
 > 1 receiving messages
   3->1 MsgHeartbeatResp Term:1 Log:0/0
   DEBUG 1 [firstindex: 12, commit: 11] sent snapshot[index: 11, term: 1] to 3 [StateProbe match=0 next=11]
-  DEBUG 1 paused sending replication messages to 3 [StateSnapshot match=0 next=11 paused pendingSnap=11]
+  DEBUG 1 paused sending replication messages to 3 [StateSnapshot match=0 next=12 paused pendingSnap=11]
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
@@ -98,7 +98,7 @@ status 1
 ----
 1: StateReplicate match=11 next=12
 2: StateReplicate match=11 next=12
-3: StateSnapshot match=0 next=11 paused pendingSnap=11
+3: StateSnapshot match=0 next=12 paused pendingSnap=11
 
 # Follower applies the snapshot. Note how it reacts with a MsgAppResp upon completion.
 # The snapshot fully catches the follower up (i.e. there are no more log entries it

--- a/testdata/snapshot_succeed_via_app_resp.txt
+++ b/testdata/snapshot_succeed_via_app_resp.txt
@@ -127,10 +127,6 @@ stabilize 1
 > 1 receiving messages
   3->1 MsgAppResp Term:1 Log:0/11
   DEBUG 1 recovered from needing snapshot, resumed sending replication messages to 3 [StateSnapshot match=11 next=12 paused pendingSnap=11]
-> 1 handling Ready
-  Ready MustSync=false:
-  Messages:
-  1->3 MsgApp Term:1 Log:1/11 Commit:11
 
 status 1
 ----
@@ -143,16 +139,9 @@ stabilize
 ----
 > 2 receiving messages
   1->2 MsgHeartbeat Term:1 Log:0/0 Commit:11
-> 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/11 Commit:11
 > 2 handling Ready
   Ready MustSync=false:
   Messages:
   2->1 MsgHeartbeatResp Term:1 Log:0/0
-> 3 handling Ready
-  Ready MustSync=false:
-  Messages:
-  3->1 MsgAppResp Term:1 Log:0/11
 > 1 receiving messages
   2->1 MsgHeartbeatResp Term:1 Log:0/0
-  3->1 MsgAppResp Term:1 Log:0/11

--- a/testdata/snapshot_succeed_via_app_resp_behind.txt
+++ b/testdata/snapshot_succeed_via_app_resp_behind.txt
@@ -124,7 +124,7 @@ stabilize 1
   DEBUG 1 received MsgAppResp(rejected, hint: (index 5, term 1)) from 3 for index 10
   DEBUG 1 decreased progress of 3 to [StateProbe match=0 next=6]
   DEBUG 1 [firstindex: 11, commit: 12] sent snapshot[index: 12, term: 1] to 3 [StateProbe match=0 next=6]
-  DEBUG 1 paused sending replication messages to 3 [StateSnapshot match=0 next=6 paused pendingSnap=12]
+  DEBUG 1 paused sending replication messages to 3 [StateSnapshot match=0 next=13 paused pendingSnap=12]
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
@@ -152,7 +152,7 @@ stabilize 1
 ----
 > 1 receiving messages
   3->1 MsgAppResp Term:1 Log:0/11
-  DEBUG 1 recovered from needing snapshot, resumed sending replication messages to 3 [StateSnapshot match=11 next=12 paused pendingSnap=12]
+  DEBUG 1 recovered from needing snapshot, resumed sending replication messages to 3 [StateSnapshot match=11 next=13 paused pendingSnap=12]
 > 1 handling Ready
   Ready MustSync=false:
   Messages:

--- a/tracker/progress.go
+++ b/tracker/progress.go
@@ -40,6 +40,14 @@ type Progress struct {
 	// In StateSnapshot, Next == PendingSnapshot + 1.
 	Next uint64
 
+	// sentCommit is the highest commit index in flight to the follower.
+	//
+	// Generally, it is monotonic, but con regress in some cases, e.g. when
+	// converting to `StateProbe` or when receiving a rejection from a follower.
+	//
+	// In StateSnapshot, sentCommit == PendingSnapshot == Next-1.
+	sentCommit uint64
+
 	// State defines how the leader should interact with the follower.
 	//
 	// When in StateProbe, leader sends at most one replication message
@@ -131,6 +139,7 @@ func (pr *Progress) BecomeProbe() {
 		pr.ResetState(StateProbe)
 		pr.Next = pr.Match + 1
 	}
+	pr.sentCommit = min(pr.sentCommit, pr.Next-1)
 }
 
 // BecomeReplicate transitions into StateReplicate, resetting Next to Match+1.
@@ -145,6 +154,7 @@ func (pr *Progress) BecomeSnapshot(snapshoti uint64) {
 	pr.ResetState(StateSnapshot)
 	pr.PendingSnapshot = snapshoti
 	pr.Next = snapshoti + 1
+	pr.sentCommit = snapshoti
 }
 
 // UpdateOnEntriesSend updates the progress on the given number of consecutive
@@ -172,6 +182,21 @@ func (pr *Progress) UpdateOnEntriesSend(entries int, bytes uint64) {
 	default:
 		panic(fmt.Sprintf("sending append in unhandled state %s", pr.State))
 	}
+}
+
+// CanBumpCommit returns true if sending the given commit index can potentially
+// advance the follower's commit index.
+func (pr *Progress) CanBumpCommit(index uint64) bool {
+	// Sending the given commit index may bump the follower's commit index up to
+	// Next-1 in normal operation, or higher in some rare cases. Allow sending a
+	// commit index eagerly only if we haven't already sent one that bumps the
+	// follower's commit all the way to Next-1.
+	return index > pr.sentCommit && pr.sentCommit < pr.Next-1
+}
+
+// SentCommit updates the sentCommit.
+func (pr *Progress) SentCommit(commit uint64) {
+	pr.sentCommit = commit
 }
 
 // MaybeUpdate is called when an MsgAppResp arrives from the follower, with the
@@ -209,6 +234,8 @@ func (pr *Progress) MaybeDecrTo(rejected, matchHint uint64) bool {
 		//
 		// TODO(tbg): why not use matchHint if it's larger?
 		pr.Next = pr.Match + 1
+		// Regress the sentCommit since it unlikely has been applied.
+		pr.sentCommit = min(pr.sentCommit, pr.Next-1)
 		return true
 	}
 
@@ -220,6 +247,8 @@ func (pr *Progress) MaybeDecrTo(rejected, matchHint uint64) bool {
 	}
 
 	pr.Next = max(min(rejected, matchHint+1), pr.Match+1)
+	// Regress the sentCommit since it unlikely has been applied.
+	pr.sentCommit = min(pr.sentCommit, pr.Next-1)
 	pr.MsgAppFlowPaused = false
 	return true
 }

--- a/tracker/progress.go
+++ b/tracker/progress.go
@@ -35,6 +35,9 @@ type Progress struct {
 	// entries with indices in (Match, Next) interval are already in flight.
 	//
 	// Invariant: 0 <= Match < Next.
+	// NB: it follows that Next >= 1.
+	//
+	// In StateSnapshot, Next == PendingSnapshot + 1.
 	Next uint64
 
 	// State defines how the leader should interact with the follower.
@@ -141,6 +144,7 @@ func (pr *Progress) BecomeReplicate() {
 func (pr *Progress) BecomeSnapshot(snapshoti uint64) {
 	pr.ResetState(StateSnapshot)
 	pr.PendingSnapshot = snapshoti
+	pr.Next = snapshoti + 1
 }
 
 // UpdateOnEntriesSend updates the progress on the given number of consecutive

--- a/tracker/progress.go
+++ b/tracker/progress.go
@@ -157,12 +157,12 @@ func (pr *Progress) BecomeSnapshot(snapshoti uint64) {
 	pr.sentCommit = snapshoti
 }
 
-// UpdateOnEntriesSend updates the progress on the given number of consecutive
-// entries being sent in a MsgApp, with the given total bytes size, appended at
-// log indices >= pr.Next.
+// SentEntries updates the progress on the given number of consecutive entries
+// being sent in a MsgApp, with the given total bytes size, appended at log
+// indices >= pr.Next.
 //
 // Must be used with StateProbe or StateReplicate.
-func (pr *Progress) UpdateOnEntriesSend(entries int, bytes uint64) {
+func (pr *Progress) SentEntries(entries int, bytes uint64) {
 	switch pr.State {
 	case StateReplicate:
 		if entries > 0 {


### PR DESCRIPTION
This commit adds a `Progress.sentCommit` field tracking the highest commit index which the leader sent to the follower. It is used to distinguish cases when a commit index update needs or doesn't need to be sent to a follower.

Touches #131