### PR TITLE
Test: Replace t.error/fatal with assert/request in [/quorum]

### DIFF
--- a/quorum/datadriven_test.go
+++ b/quorum/datadriven_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/datadriven"
+	"github.com/stretchr/testify/require"
 )
 
 // TestDataDriven parses and executes the test cases in ./testdata/*. An entry
@@ -68,9 +69,7 @@ func TestDataDriven(t *testing.T) {
 					case "cfgj":
 						joint = true
 						if arg.Vals[i] == "zero" {
-							if len(arg.Vals) != 1 {
-								t.Fatalf("cannot mix 'zero' into configuration")
-							}
+							require.Len(t, arg.Vals, 1, "cannot mix 'zero' into configuration")
 						} else {
 							var n uint64
 							arg.Scan(t, i, &n)
@@ -81,11 +80,9 @@ func TestDataDriven(t *testing.T) {
 						// Register placeholders as zeroes.
 						if arg.Vals[i] != "_" {
 							arg.Scan(t, i, &n)
-							if n == 0 {
-								// This is a restriction caused by the above
-								// special-casing for _.
-								t.Fatalf("cannot use 0 as idx")
-							}
+							// This is a restriction caused by the above
+							// special-casing for _.
+							require.NotZero(t, n, "cannot use 0 as idx")
 						}
 						idxs = append(idxs, Index(n))
 					case "votes":

--- a/quorum/quick_test.go
+++ b/quorum/quick_test.go
@@ -20,6 +20,8 @@ import (
 	"reflect"
 	"testing"
 	"testing/quick"
+
+	"github.com/stretchr/testify/require"
 )
 
 // TestQuick uses quickcheck to heuristically assert that the main
@@ -37,9 +39,7 @@ func TestQuick(t *testing.T) {
 		fn2 := func(c memberMap, l idxMap) uint64 {
 			return uint64(alternativeMajorityCommittedIndex(MajorityConfig(c), mapAckIndexer(l)))
 		}
-		if err := quick.CheckEqual(fn1, fn2, cfg); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, quick.CheckEqual(fn1, fn2, cfg))
 	})
 }
 


### PR DESCRIPTION
Refactor: Replacing t.Error/t.Fatal with assert/require

This commit tries to eliminate boilerplate code in the testing suite by replacing occurrences
of t.Error and t.Fatal with assertions from the assert and require packages.

Changes Made:

- Replaced instances of t.Error with assert
- Replaced instances of t.Fatal with require

Affected Files:
- [quorum/datadriven_test.go]
- [quorum/quick_test.go]

Part of: #146