### PR TITLE
Test: Replace t.error/fatal with assert/request in [/rafttest]

### DIFF
--- a/rafttest/network_test.go
+++ b/rafttest/network_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"go.etcd.io/raft/v3/raftpb"
 )
 
@@ -45,9 +47,8 @@ func TestNetworkDrop(t *testing.T) {
 	}
 
 	drop := sent - received
-	if drop > int((droprate+0.1)*float64(sent)) || drop < int((droprate-0.1)*float64(sent)) {
-		t.Errorf("drop = %d, want around %.2f", drop, droprate*float64(sent))
-	}
+	assert.LessOrEqual(t, drop, int((droprate+0.1)*float64(sent)))
+	assert.GreaterOrEqual(t, drop, int((droprate-0.1)*float64(sent)))
 }
 
 func TestNetworkDelay(t *testing.T) {
@@ -66,7 +67,5 @@ func TestNetworkDelay(t *testing.T) {
 
 	w := time.Duration(float64(sent)*delayrate/2) * delay
 	// there is some overhead in the send call since it generates random numbers.
-	if total < w {
-		t.Errorf("total = %v, want > %v", total, w)
-	}
+	assert.GreaterOrEqual(t, total, w)
 }

--- a/rafttest/node_test.go
+++ b/rafttest/node_test.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"go.etcd.io/raft/v3"
 )
 
@@ -39,9 +41,7 @@ func TestBasicProgress(t *testing.T) {
 		nodes[0].Propose(context.TODO(), []byte("somedata"))
 	}
 
-	if !waitCommitConverge(nodes, 100) {
-		t.Errorf("commits failed to converge!")
-	}
+	assert.True(t, waitCommitConverge(nodes, 100))
 
 	for _, n := range nodes {
 		n.stop()
@@ -79,9 +79,7 @@ func TestRestart(t *testing.T) {
 	}
 	nodes[k1].restart()
 
-	if !waitCommitConverge(nodes, 120) {
-		t.Errorf("commits failed to converge!")
-	}
+	assert.True(t, waitCommitConverge(nodes, 120))
 
 	for _, n := range nodes {
 		n.stop()
@@ -118,9 +116,7 @@ func TestPause(t *testing.T) {
 	}
 	nodes[1].resume()
 
-	if !waitCommitConverge(nodes, 120) {
-		t.Errorf("commits failed to converge!")
-	}
+	assert.True(t, waitCommitConverge(nodes, 120))
 
 	for _, n := range nodes {
 		n.stop()


### PR DESCRIPTION
Refactor: Replacing t.Error/t.Fatal with assert/require

This commit tries to eliminate boilerplate code in the testing suite by replacing occurrences
of t.Error and t.Fatal with assertions from the assert and require packages.

Changes Made:

- Replaced instances of t.Error with assert
- Replaced instances of t.Fatal with require

Affected Files:
- [rafttest/network_test.go]
- [rafttest/node_test.go]

Part of: #146