### PR TITLE
Test: Replace t.error/fatal with assert/request in [/tracker/inflights_test.go]

### DIFF
--- a/tracker/inflights_test.go
+++ b/tracker/inflights_test.go
@@ -17,6 +17,7 @@ package tracker
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -203,14 +204,10 @@ func TestInflightsFull(t *testing.T) {
 
 			addUntilFull := func(begin, end int) {
 				for i := begin; i < end; i++ {
-					if in.Full() {
-						t.Fatalf("full at %d, want %d", i, end)
-					}
+					require.False(t, in.Full(), "full at %d, want %d", i, end)
 					in.Add(uint64(i), uint64(100+i))
 				}
-				if !in.Full() {
-					t.Fatalf("not full at %d", end)
-				}
+				require.True(t, in.Full(), "not full at %d", end)
 			}
 
 			addUntilFull(0, tc.fullAt)
@@ -218,9 +215,7 @@ func TestInflightsFull(t *testing.T) {
 			addUntilFull(tc.fullAt, tc.againAt)
 
 			defer func() {
-				if r := recover(); r == nil {
-					t.Errorf("Add() did not panic")
-				}
+				assert.NotNil(t, recover(), "Add() did not panic")
 			}()
 			in.Add(100, 1024)
 		})


### PR DESCRIPTION
Refactor: Replacing t.Error/t.Fatal with assert/require

This commit tries to eliminate boilerplate code in the testing suite by replacing occurrences
of t.Error and t.Fatal with assertions from the assert and require packages.

Changes Made:

- Replaced instances of t.Error with assert
- Replaced instances of t.Fatal with require

Affected Files:
- [/tracker/inflights_test.go]

Part of: #146