### PR TITLE
Test: Replace t.error/fatal with assert/request in [util_test.go] 

### DIFF
--- a/util_test.go
+++ b/util_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	pb "go.etcd.io/raft/v3/raftpb"
@@ -137,9 +138,7 @@ func TestIsResponseMsg(t *testing.T) {
 
 	for i, tt := range tests {
 		got := IsResponseMsg(tt.msgt)
-		if got != tt.isResponse {
-			t.Errorf("#%d: got %v, want %v", i, got, tt.isResponse)
-		}
+		assert.Equal(t, tt.isResponse, got, "#%d", i)
 	}
 }
 


### PR DESCRIPTION
Refactor: Replacing t.Error/t.Fatal with assert/require

This commit tries to eliminate boilerplate code in the testing suite by replacing occurrences
of t.Error and t.Fatal with assertions from the assert and require packages.

Changes Made:

- Replaced instances of t.Error with assert
- Replaced instances of t.Fatal with require

Affected Files:
- [util_test.go]

Part of: #146