### PR TITLE
github/workflows: prevent arm64 workloads from running on forks

### DIFF
--- a/.github/workflows/test_template.yaml
+++ b/.github/workflows/test_template.yaml
@@ -1,5 +1,5 @@
 name: Workflow Test Template
-on: 
+on:
   workflow_call:
     inputs:
       runs-on:
@@ -15,6 +15,8 @@ permissions: read-all
 jobs:
   run:
     runs-on: ${{ inputs.runs-on }}
+    # this is to prevent arm64 jobs from running at forked projects
+    if: inputs.arch != 'arm64' || github.repository == 'etcd-io/raft'
     strategy:
       fail-fast: false
       matrix:
@@ -26,7 +28,7 @@ jobs:
       - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
           go-version: ${{ steps.goversion.outputs.goversion }}
-      - env: 
+      - env:
           TARGET: ${{ matrix.target }}
         run: |
           go clean -testcache


### PR DESCRIPTION
I stumbled on this issue after my pull request from yesterday and realized that the condition to run only on etcd-io's repository is not set here, as we do have it in other repositories (etcd, bbolt).

User forks don't have access to ARM64 runners, which makes the jobs fail after a timeout.