### PR TITLE
go version bump from 1.22.5 to 1.22.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module go.etcd.io/raft/v3
 
 go 1.22
 
-toolchain go1.22.5
+toolchain go1.22.6
 
 require (
 	github.com/cockroachdb/datadriven v1.0.2

--- a/tools/mod/go.mod
+++ b/tools/mod/go.mod
@@ -2,7 +2,7 @@ module go.etcd.io/raft/tools/v3
 
 go 1.22
 
-toolchain go1.22.5
+toolchain go1.22.6
 
 require (
 	github.com/alexkohler/nakedret v1.0.0


### PR DESCRIPTION
Reference: https://github.com/etcd-io/etcd/issues/18419