### PR TITLE
replace sort.Slice with slices.Sort, slices.SortFunc

### DIFF
--- a/confchange/restore_test.go
+++ b/confchange/restore_test.go
@@ -17,7 +17,7 @@ package confchange
 import (
 	"math/rand"
 	"reflect"
-	"sort"
+	"slices"
 	"testing"
 	"testing/quick"
 
@@ -104,7 +104,7 @@ func TestRestore(t *testing.T) {
 			cs.VotersOutgoing,
 			cs.LearnersNext,
 		} {
-			sort.Slice(sl, func(i, j int) bool { return sl[i] < sl[j] })
+			slices.Sort(sl)
 		}
 
 		cs2 := chg.Tracker.ConfState()

--- a/quorum/majority.go
+++ b/quorum/majority.go
@@ -15,10 +15,10 @@
 package quorum
 
 import (
+	"cmp"
 	"fmt"
 	"math"
 	"slices"
-	"sort"
 	"strings"
 )
 
@@ -30,7 +30,7 @@ func (c MajorityConfig) String() string {
 	for id := range c {
 		sl = append(sl, id)
 	}
-	sort.Slice(sl, func(i, j int) bool { return sl[i] < sl[j] })
+	slices.Sort(sl)
 	var buf strings.Builder
 	buf.WriteByte('(')
 	for i := range sl {
@@ -68,11 +68,11 @@ func (c MajorityConfig) Describe(l AckedIndexer) string {
 	}
 
 	// Sort by index
-	sort.Slice(info, func(i, j int) bool {
-		if info[i].idx == info[j].idx {
-			return info[i].id < info[j].id
+	slices.SortFunc(info, func(a, b tup) int {
+		if n := cmp.Compare(a.idx, b.idx); n != 0 {
+			return n
 		}
-		return info[i].idx < info[j].idx
+		return cmp.Compare(a.id, b.id)
 	})
 
 	// Populate .bar.
@@ -83,8 +83,8 @@ func (c MajorityConfig) Describe(l AckedIndexer) string {
 	}
 
 	// Sort by ID.
-	sort.Slice(info, func(i, j int) bool {
-		return info[i].id < info[j].id
+	slices.SortFunc(info, func(a, b tup) int {
+		return cmp.Compare(a.id, b.id)
 	})
 
 	var buf strings.Builder
@@ -109,7 +109,7 @@ func (c MajorityConfig) Slice() []uint64 {
 	for id := range c {
 		sl = append(sl, id)
 	}
-	sort.Slice(sl, func(i, j int) bool { return sl[i] < sl[j] })
+	slices.Sort(sl)
 	return sl
 }
 

--- a/raft.go
+++ b/raft.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"math"
 	"math/big"
-	"sort"
+	"slices"
 	"strings"
 	"sync"
 
@@ -1047,7 +1047,7 @@ func (r *raft) campaign(t CampaignType) {
 		for id := range idMap {
 			ids = append(ids, id)
 		}
-		sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+		slices.Sort(ids)
 	}
 	for _, id := range ids {
 		if id == r.id {

--- a/raftpb/confstate.go
+++ b/raftpb/confstate.go
@@ -17,7 +17,7 @@ package raftpb
 import (
 	"fmt"
 	"reflect"
-	"sort"
+	"slices"
 )
 
 // Equivalent returns a nil error if the inputs describe the same configuration.
@@ -27,7 +27,7 @@ func (cs ConfState) Equivalent(cs2 ConfState) error {
 	orig1, orig2 := cs1, cs2
 	s := func(sl *[]uint64) {
 		*sl = append([]uint64(nil), *sl...)
-		sort.Slice(*sl, func(i, j int) bool { return (*sl)[i] < (*sl)[j] })
+		slices.Sort(*sl)
 	}
 
 	for _, cs := range []*ConfState{&cs1, &cs2} {

--- a/tracker/progress.go
+++ b/tracker/progress.go
@@ -16,7 +16,7 @@ package tracker
 
 import (
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 )
 
@@ -305,9 +305,7 @@ func (m ProgressMap) String() string {
 	for k := range m {
 		ids = append(ids, k)
 	}
-	sort.Slice(ids, func(i, j int) bool {
-		return ids[i] < ids[j]
-	})
+	slices.Sort(ids)
 	var buf strings.Builder
 	for _, id := range ids {
 		fmt.Fprintf(&buf, "%d: %s\n", id, m[id])

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -17,7 +17,6 @@ package tracker
 import (
 	"fmt"
 	"slices"
-	"sort"
 	"strings"
 
 	"go.etcd.io/raft/v3/quorum"
@@ -225,7 +224,7 @@ func (p *ProgressTracker) VoterNodes() []uint64 {
 	for id := range m {
 		nodes = append(nodes, id)
 	}
-	sort.Slice(nodes, func(i, j int) bool { return nodes[i] < nodes[j] })
+	slices.Sort(nodes)
 	return nodes
 }
 
@@ -238,7 +237,7 @@ func (p *ProgressTracker) LearnerNodes() []uint64 {
 	for id := range p.Learners {
 		nodes = append(nodes, id)
 	}
-	sort.Slice(nodes, func(i, j int) bool { return nodes[i] < nodes[j] })
+	slices.Sort(nodes)
 	return nodes
 }
 


### PR DESCRIPTION
Replace `sort.Slice` with `slices.Sort` and `slices.SortFunc`. 
As mentioned in the comments of `sort.Slice`, the newer method is more ergonomic and run faster.