### PR TITLE
fix incorrect usage in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ To start a three-node cluster
     MaxInflightMsgs: 256,
   }
   // Set peer list to all nodes in the cluster.
-  // Note that they need to be started separately.
+  // Note that other nodes in the cluster, apart from this node, need to be started separately.
   n := raft.StartNode(c, []raft.Peer{{ID: 0x01}, {ID: 0x02}, {ID: 0x03}})
 ```
 


### PR DESCRIPTION
The `raft.StartNode` method requires the full list of nodes in the cluster to establish the voters configuration.