### PR TITLE
Remove defunct arm64 github actions workflow

### DIFF
--- a/.github/workflows/test_arm64.yaml
+++ b/.github/workflows/test_arm64.yaml
@@ -1,9 +1,0 @@
-name: Test ARM64
-permissions: read-all
-on: [push, pull_request]
-jobs:
-  test-linux-arm64-cpu-race:
-    uses: ./.github/workflows/test_template.yaml
-    with:
-      runs-on: actuated-arm64-8cpu-8gb
-      targets: "['linux-arm64-unit-4-cpu-race']"


### PR DESCRIPTION
The `arm64` presubmit has been moved to prow in https://github.com/kubernetes/test-infra/pull/33715.