### PR TITLE
perf: optimize MemoryStorage.Compact method by improving memory allocation

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -263,10 +263,9 @@ func (ms *MemoryStorage) Compact(compactIndex uint64) error {
 	// NB: allocate a new slice instead of reusing the old ms.ents. Entries in
 	// ms.ents are immutable, and can be referenced from outside MemoryStorage
 	// through slices returned by ms.Entries().
-	ents := make([]pb.Entry, 1, uint64(len(ms.ents))-i)
-	ents[0].Index = ms.ents[i].Index
-	ents[0].Term = ms.ents[i].Term
-	ents = append(ents, ms.ents[i+1:]...)
+	remainingCount := len(ms.ents) - int(i)
+	ents := make([]pb.Entry, remainingCount)
+	copy(ents, ms.ents[i:])
 	ms.ents = ents
 	return nil
 }

--- a/storage.go
+++ b/storage.go
@@ -263,7 +263,7 @@ func (ms *MemoryStorage) Compact(compactIndex uint64) error {
 	// NB: allocate a new slice instead of reusing the old ms.ents. Entries in
 	// ms.ents are immutable, and can be referenced from outside MemoryStorage
 	// through slices returned by ms.Entries().
-	remainingCount := len(ms.ents) - int(i)
+	remainingCount := uint64(len(ms.ents)) - i
 	ents := make([]pb.Entry, remainingCount)
 	copy(ents, ms.ents[i:])
 	ms.ents = ents


### PR DESCRIPTION
Avoiding the use of `append`, and directly copying remaining entries to a new slice for better performance.