### PR TITLE
Bump go linter 1.24

### DIFF
--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@051d91933864810ecd5e2ea2cfd98f6a5bca5347 # v6.3.2
         with:
-          version: v1.60.1
+          version: v1.63.4
       - name: protoc
         uses: arduino/setup-protoc@149f6c87b92550901b26acd1632e11c3662e381f # v1.3.0
         with:


### PR DESCRIPTION
https://github.com/etcd-io/raft/pull/268 CI failure is due to linter version used is built using go1.23.

This PR bumps the go-linter version used in CI

@ivanvc @henrybear327
