### PR TITLE
decouple raftLog - phase 1: introduce the new type controlflowLog.

### DIFF
--- a/log.go
+++ b/log.go
@@ -28,6 +28,11 @@ type raftLog struct {
 	// they will be saved into storage.
 	unstable unstable
 
+	// type embedding of controlflowLog
+	controlflowLog
+}
+
+type controlflowLog struct {
 	// committed is the highest log position that is known to be in
 	// stable storage on a quorum of nodes.
 	committed uint64
@@ -86,14 +91,16 @@ func newLogWithSize(storage Storage, logger Logger, maxApplyingEntsSize entryEnc
 			offsetInProgress: lastIndex + 1,
 			logger:           logger,
 		},
-		maxApplyingEntsSize: maxApplyingEntsSize,
+		controlflowLog: controlflowLog{
+			maxApplyingEntsSize: maxApplyingEntsSize,
 
-		// Initialize our committed and applied pointers to the time of the last compaction.
-		committed: firstIndex - 1,
-		applying:  firstIndex - 1,
-		applied:   firstIndex - 1,
+			// Initialize our committed and applied pointers to the time of the last compaction.
+			committed: firstIndex - 1,
+			applying:  firstIndex - 1,
+			applied:   firstIndex - 1,
 
-		logger: logger,
+			logger: logger,
+		},
 	}
 }
 


### PR DESCRIPTION
#142 - this is about to decouple the type raftLog.

since this change may include a lot of cascaded code changes on several types, i'd like to split this refactor into two phase.

phase 1: introduce the type controlflowLog. add it into raftLog as embedding type.
i move all control flow related fields into type controlflowLog.

phase 2: remove the embedding type. modify type reference in all other files.

in this PR, i implemented phase 1. please review it.