### PR TITLE
golangci-lint-action from 6.3.2 to 8.0.0

### DIFF
--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -11,9 +11,9 @@ jobs:
         with:
           go-version: ${{ steps.goversion.outputs.goversion }}
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@051d91933864810ecd5e2ea2cfd98f6a5bca5347 # v6.3.2
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
-          version: v1.64.5
+          version: v2.1.6
       - name: protoc
         uses: arduino/setup-protoc@149f6c87b92550901b26acd1632e11c3662e381f # v1.3.0
         with:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,50 +1,59 @@
+version: "2"
 run:
   timeout: 30m
-  skip-files:
-    - "^zz_generated.*"
-formatters:
-  enable:
-    - gci
-  settings: # please keep this alphabetized
-    gci:
-      sections:
-        - standard
-        - default
-        - prefix(go.etcd.io)
-issues:
-  max-same-issues: 0
-  # Excluding configuration per-path, per-linter, per-text and per-source
-  exclude-rules:
-    # exclude ineffassing linter for generated files for conversion
-    - path: conversion\.go
-      linters:
-        - ineffassign
-
 linters:
-  disable-all: true
-  enable: # please keep this alphabetized
+  default: none
+  # please keep this alphabetized
+  enable:
   # Don't use soon to deprecated[1] linters that lead to false
   # https://github.com/golangci/golangci-lint/issues/1841
   # - deadcode
   # - structcheck
   # - varcheck
-    - goimports
     - ineffassign
     - revive
     - staticcheck
-    - stylecheck
     - unused
     - unconvert # Remove unnecessary type conversions
     - usetesting
-
-linters-settings: # please keep this alphabetized
-  goimports:
-    local-prefixes: go.etcd.io # Put imports beginning with prefix after 3rd-party packages.
-  staticcheck:
-    checks:
-      - "all"
-      - "-SA1019" # TODO(fix) Using a deprecated function, variable, constant or field
-      - "-SA2002"  # TODO(fix) Called testing.T.FailNow or SkipNow in a goroutine, which isn’t allowed
-  stylecheck:
-    checks:
-      - "ST1019"  # Importing the same package multiple times.
+  # please keep this alphabetized
+  settings:
+    staticcheck:
+      checks:
+        - all
+        - -SA1019 # TODO(fix) Using a deprecated function, variable, constant or field
+        - -SA2002 # TODO(fix) Called testing.T.FailNow or SkipNow in a goroutine, which isn’t allowed
+        - -QF1008
+        - -QF1003
+        - -QF1001
+        - -S1019
+  # Excluding configuration per-path, per-linter, per-text and per-source
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      # exclude ineffassing linter for generated files for conversion
+      - linters:
+          - ineffassign
+        path: conversion\.go
+issues:
+  max-same-issues: 0
+formatters:
+  enable:
+    - gci
+    - goimports
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(go.etcd.io)
+    goimports:
+      local-prefixes:
+        - go.etcd.io
+  exclusions:
+    generated: lax


### PR DESCRIPTION
[This](https://github.com/etcd-io/raft/actions/runs/14848426347/job/41687275103?pr=293) CI has failed due to the late version of golang ci lint. So I updated it.