### PR TITLE
`MustSync` should return `true` if the HardState.Commit differs from previous value

### DIFF
--- a/node_test.go
+++ b/node_test.go
@@ -504,7 +504,7 @@ func TestNodeStart(t *testing.T) {
 			HardState:        raftpb.HardState{Term: 2, Commit: 3, Vote: 1},
 			Entries:          nil,
 			CommittedEntries: []raftpb.Entry{{Term: 2, Index: 3, Data: []byte("foo")}},
-			MustSync:         false,
+			MustSync:         true,
 		},
 	}
 	storage := NewMemoryStorage()

--- a/rawnode.go
+++ b/rawnode.go
@@ -196,7 +196,7 @@ func MustSync(st, prevst pb.HardState, entsnum int) bool {
 	// currentTerm
 	// votedFor
 	// log entries[]
-	return entsnum != 0 || st.Vote != prevst.Vote || st.Term != prevst.Term
+	return entsnum != 0 || st.Vote != prevst.Vote || st.Term != prevst.Term || st.Commit != prevst.Commit
 }
 
 func needStorageAppendMsg(r *raft, rd Ready) bool {

--- a/rawnode_test.go
+++ b/rawnode_test.go
@@ -574,7 +574,7 @@ func TestRawNodeStart(t *testing.T) {
 		HardState:        pb.HardState{Term: 1, Commit: 3, Vote: 1},
 		Entries:          nil, // emitted & checked in intermediate Ready cycle
 		CommittedEntries: entries,
-		MustSync:         false, // since we're only applying, not appending
+		MustSync:         true, // we also need to sync the hard state
 	}
 
 	storage := NewMemoryStorage()
@@ -646,7 +646,7 @@ func TestRawNodeStart(t *testing.T) {
 	require.True(t, rawNode.HasReady())
 	rd = rawNode.Ready()
 	require.Empty(t, rd.Entries)
-	require.False(t, rd.MustSync)
+	require.True(t, rd.MustSync)
 	rawNode.Advance(rd)
 
 	rd.SoftState, want.SoftState = nil, nil

--- a/testdata/async_storage_writes.txt
+++ b/testdata/async_storage_writes.txt
@@ -146,7 +146,7 @@ stabilize
 > 3 receiving messages
   AppendThread->3 MsgStorageAppendResp Term:1 Log:1/11
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:11
   CommittedEntries:
   1/11 EntryNormal ""
@@ -171,7 +171,7 @@ stabilize
   Responses:
   ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/11 EntryNormal ""]
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:11
   CommittedEntries:
   1/11 EntryNormal ""
@@ -183,7 +183,7 @@ stabilize
     ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/11 EntryNormal ""]
   ]
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:11
   CommittedEntries:
   1/11 EntryNormal ""
@@ -590,7 +590,7 @@ ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/12 EntryNormal "pro
 process-ready 1 2 3
 ----
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:14
   CommittedEntries:
   1/14 EntryNormal "prop_3"
@@ -618,7 +618,7 @@ process-ready 1 2 3
 > 1 handling Ready
   <empty Ready>
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:14
   CommittedEntries:
   1/14 EntryNormal "prop_3"
@@ -631,7 +631,7 @@ process-ready 1 2 3
     ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/14 EntryNormal "prop_3"]
   ]
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:14
   CommittedEntries:
   1/14 EntryNormal "prop_3"
@@ -702,7 +702,7 @@ ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/13 EntryNormal "pro
 process-ready 1 2 3
 ----
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:15
   CommittedEntries:
   1/15 EntryNormal "prop_4"
@@ -728,7 +728,7 @@ process-ready 1 2 3
 > 1 handling Ready
   <empty Ready>
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:15
   CommittedEntries:
   1/15 EntryNormal "prop_4"
@@ -740,7 +740,7 @@ process-ready 1 2 3
     ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/15 EntryNormal "prop_4"]
   ]
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:15
   CommittedEntries:
   1/15 EntryNormal "prop_4"

--- a/testdata/campaign.txt
+++ b/testdata/campaign.txt
@@ -88,7 +88,7 @@ stabilize
   2->1 MsgAppResp Term:1 Log:0/3
   3->1 MsgAppResp Term:1 Log:0/3
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:3
   CommittedEntries:
   1/3 EntryNormal ""
@@ -100,14 +100,14 @@ stabilize
 > 3 receiving messages
   1->3 MsgApp Term:1 Log:1/3 Commit:3
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:3
   CommittedEntries:
   1/3 EntryNormal ""
   Messages:
   2->1 MsgAppResp Term:1 Log:0/3
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:3
   CommittedEntries:
   1/3 EntryNormal ""

--- a/testdata/campaign_learner_must_vote.txt
+++ b/testdata/campaign_learner_must_vote.txt
@@ -140,7 +140,7 @@ stabilize 2 3
 > 2 receiving messages
   3->2 MsgAppResp Term:2 Log:0/5
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:2 Vote:2 Commit:5
   CommittedEntries:
   2/5 EntryNormal ""
@@ -149,7 +149,7 @@ stabilize 2 3
 > 3 receiving messages
   2->3 MsgApp Term:2 Log:2/5 Commit:5
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:2 Vote:2 Commit:5
   CommittedEntries:
   2/5 EntryNormal ""

--- a/testdata/checkquorum.txt
+++ b/testdata/checkquorum.txt
@@ -206,7 +206,7 @@ stabilize
   1->2 MsgAppResp Term:3 Log:0/12
   3->2 MsgAppResp Term:3 Log:0/12
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:3 Vote:2 Commit:12
   CommittedEntries:
   3/12 EntryNormal ""
@@ -218,14 +218,14 @@ stabilize
 > 3 receiving messages
   2->3 MsgApp Term:3 Log:3/12 Commit:12
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:3 Vote:2 Commit:12
   CommittedEntries:
   3/12 EntryNormal ""
   Messages:
   1->2 MsgAppResp Term:3 Log:0/12
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:3 Commit:12
   CommittedEntries:
   3/12 EntryNormal ""

--- a/testdata/confchange_disable_validation.txt
+++ b/testdata/confchange_disable_validation.txt
@@ -43,7 +43,7 @@ Entries:
 # Dummy entry comes up for application.
 process-ready 1
 ----
-Ready MustSync=false:
+Ready MustSync=true:
 HardState Term:1 Vote:1 Commit:5
 CommittedEntries:
 1/4 EntryNormal "foo"
@@ -66,7 +66,7 @@ stabilize
   1/5 EntryConfChangeV2 l2 l3
   INFO 1 switched to configuration voters=(1)&&(1) learners=(2 3)
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:6
   CommittedEntries:
   1/6 EntryConfChangeV2

--- a/testdata/confchange_v1_add_single.txt
+++ b/testdata/confchange_v1_add_single.txt
@@ -46,7 +46,7 @@ stabilize
   1/3 EntryNormal ""
   1/4 EntryConfChange v2
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:4
   CommittedEntries:
   1/3 EntryNormal ""
@@ -86,7 +86,7 @@ stabilize
   INFO 2 [commit: 4, lastindex: 4, lastterm: 1] restored snapshot [index: 4, term: 1]
   INFO 2 [commit: 4] restored snapshot [index: 4, term: 1]
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Commit:4
   Snapshot Index:4 Term:1 ConfState:Voters:[1 2] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
   Messages:

--- a/testdata/confchange_v1_remove_leader.txt
+++ b/testdata/confchange_v1_remove_leader.txt
@@ -95,7 +95,7 @@ stabilize 1
   2->1 MsgAppResp Term:1 Log:0/4
   2->1 MsgAppResp Term:1 Log:0/5
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:5
   CommittedEntries:
   1/4 EntryConfChange r1
@@ -175,7 +175,7 @@ stabilize
   3->1 MsgAppResp Term:1 Log:0/6
   3->1 MsgAppResp Term:1 Log:0/6
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:6
   CommittedEntries:
   1/6 EntryNormal "bar"
@@ -187,14 +187,14 @@ stabilize
 > 3 receiving messages
   1->3 MsgApp Term:1 Log:1/6 Commit:6
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:6
   CommittedEntries:
   1/6 EntryNormal "bar"
   Messages:
   2->1 MsgAppResp Term:1 Log:0/6
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:6
   CommittedEntries:
   1/6 EntryNormal "bar"

--- a/testdata/confchange_v1_remove_leader_stepdown.txt
+++ b/testdata/confchange_v1_remove_leader_stepdown.txt
@@ -94,7 +94,7 @@ stabilize 1
   2->1 MsgAppResp Term:1 Log:0/4
   2->1 MsgAppResp Term:1 Log:0/5
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:5
   CommittedEntries:
   1/4 EntryConfChange r1

--- a/testdata/confchange_v2_add_double_auto.txt
+++ b/testdata/confchange_v2_add_double_auto.txt
@@ -53,7 +53,7 @@ Entries:
 # it has to since we're carrying out two additions at once.
 process-ready 1
 ----
-Ready MustSync=false:
+Ready MustSync=true:
 HardState Term:1 Vote:1 Commit:4
 CommittedEntries:
 1/3 EntryNormal ""
@@ -109,7 +109,7 @@ stabilize 1 2
   INFO 2 [commit: 4, lastindex: 4, lastterm: 1] restored snapshot [index: 4, term: 1]
   INFO 2 [commit: 4] restored snapshot [index: 4, term: 1]
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Commit:4
   Snapshot Index:4 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[1] Learners:[] LearnersNext:[] AutoLeave:true
   Messages:
@@ -132,7 +132,7 @@ stabilize 1 2
 > 1 receiving messages
   2->1 MsgAppResp Term:1 Log:0/5
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:5
   CommittedEntries:
   1/5 EntryConfChangeV2
@@ -142,7 +142,7 @@ stabilize 1 2
 > 2 receiving messages
   1->2 MsgApp Term:1 Log:1/5 Commit:5
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Commit:5
   CommittedEntries:
   1/5 EntryConfChangeV2
@@ -185,7 +185,7 @@ stabilize 1 3
   INFO 3 [commit: 5, lastindex: 5, lastterm: 1] restored snapshot [index: 5, term: 1]
   INFO 3 [commit: 5] restored snapshot [index: 5, term: 1]
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Commit:5
   Snapshot Index:5 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
   Messages:
@@ -267,7 +267,7 @@ stabilize 1
   2->1 MsgAppResp Term:1 Log:0/6
   3->1 MsgAppResp Term:1 Log:0/6
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:6
   CommittedEntries:
   1/6 EntryConfChangeV2 r2 r3
@@ -343,7 +343,7 @@ stabilize
   3->1 MsgAppResp Term:1 Log:0/8
   3->1 MsgAppResp Term:1 Log:0/9
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:9
   CommittedEntries:
   1/7 EntryNormal "foo"
@@ -366,7 +366,7 @@ stabilize
   1->3 MsgApp Term:1 Log:1/9 Commit:8
   1->3 MsgApp Term:1 Log:1/9 Commit:9
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Commit:9
   CommittedEntries:
   1/7 EntryNormal "foo"
@@ -378,7 +378,7 @@ stabilize
   2->1 MsgAppResp Term:1 Log:0/9
   INFO 2 switched to configuration voters=(1)
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Commit:9
   CommittedEntries:
   1/7 EntryNormal "foo"

--- a/testdata/confchange_v2_add_double_implicit.txt
+++ b/testdata/confchange_v2_add_double_implicit.txt
@@ -49,7 +49,7 @@ stabilize 1 2
   1/3 EntryNormal ""
   1/4 EntryConfChangeV2 v2
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:4
   CommittedEntries:
   1/3 EntryNormal ""
@@ -92,7 +92,7 @@ stabilize 1 2
   INFO 2 [commit: 4, lastindex: 4, lastterm: 1] restored snapshot [index: 4, term: 1]
   INFO 2 [commit: 4] restored snapshot [index: 4, term: 1]
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Commit:4
   Snapshot Index:4 Term:1 ConfState:Voters:[1 2] VotersOutgoing:[1] Learners:[] LearnersNext:[] AutoLeave:true
   Messages:
@@ -115,7 +115,7 @@ stabilize 1 2
 > 1 receiving messages
   2->1 MsgAppResp Term:1 Log:0/5
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:5
   CommittedEntries:
   1/5 EntryConfChangeV2
@@ -125,7 +125,7 @@ stabilize 1 2
 > 2 receiving messages
   1->2 MsgApp Term:1 Log:1/5 Commit:5
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Commit:5
   CommittedEntries:
   1/5 EntryConfChangeV2

--- a/testdata/confchange_v2_add_single_auto.txt
+++ b/testdata/confchange_v2_add_single_auto.txt
@@ -47,7 +47,7 @@ stabilize
   1/3 EntryNormal ""
   1/4 EntryConfChangeV2 v2
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:4
   CommittedEntries:
   1/3 EntryNormal ""
@@ -87,7 +87,7 @@ stabilize
   INFO 2 [commit: 4, lastindex: 4, lastterm: 1] restored snapshot [index: 4, term: 1]
   INFO 2 [commit: 4] restored snapshot [index: 4, term: 1]
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Commit:4
   Snapshot Index:4 Term:1 ConfState:Voters:[1 2] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
   Messages:

--- a/testdata/confchange_v2_add_single_explicit.txt
+++ b/testdata/confchange_v2_add_single_explicit.txt
@@ -47,7 +47,7 @@ stabilize 1 2
   1/3 EntryNormal ""
   1/4 EntryConfChangeV2 v2
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:4
   CommittedEntries:
   1/3 EntryNormal ""
@@ -87,7 +87,7 @@ stabilize 1 2
   INFO 2 [commit: 4, lastindex: 4, lastterm: 1] restored snapshot [index: 4, term: 1]
   INFO 2 [commit: 4] restored snapshot [index: 4, term: 1]
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Commit:4
   Snapshot Index:4 Term:1 ConfState:Voters:[1 2] VotersOutgoing:[1] Learners:[] LearnersNext:[] AutoLeave:false
   Messages:
@@ -135,7 +135,7 @@ stabilize
   2->1 MsgAppResp Term:1 Log:0/5
   2->1 MsgAppResp Term:1 Log:0/6
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:6
   CommittedEntries:
   1/5 EntryNormal ""
@@ -148,7 +148,7 @@ stabilize
   1->2 MsgApp Term:1 Log:1/6 Commit:5
   1->2 MsgApp Term:1 Log:1/6 Commit:6
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Commit:6
   CommittedEntries:
   1/5 EntryNormal ""
@@ -186,7 +186,7 @@ stabilize
 > 1 receiving messages
   2->1 MsgAppResp Term:1 Log:0/7
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:7
   CommittedEntries:
   1/7 EntryNormal ""
@@ -195,7 +195,7 @@ stabilize
 > 2 receiving messages
   1->2 MsgApp Term:1 Log:1/7 Commit:7
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Commit:7
   CommittedEntries:
   1/7 EntryNormal ""

--- a/testdata/confchange_v2_replace_leader.txt
+++ b/testdata/confchange_v2_replace_leader.txt
@@ -76,7 +76,7 @@ stabilize
   2->1 MsgAppResp Term:1 Log:0/4
   3->1 MsgAppResp Term:1 Log:0/4
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:4
   CommittedEntries:
   1/4 EntryConfChangeV2 r1 v4
@@ -93,7 +93,7 @@ stabilize
   Messages:
   1->4 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 r1 v4]
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:4
   CommittedEntries:
   1/4 EntryConfChangeV2 r1 v4
@@ -101,7 +101,7 @@ stabilize
   2->1 MsgAppResp Term:1 Log:0/4
   INFO 2 switched to configuration voters=(2 3 4)&&(1 2 3)
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:4
   CommittedEntries:
   1/4 EntryConfChangeV2 r1 v4
@@ -136,7 +136,7 @@ stabilize
   INFO 4 [commit: 4, lastindex: 4, lastterm: 1] restored snapshot [index: 4, term: 1]
   INFO 4 [commit: 4] restored snapshot [index: 4, term: 1]
 > 4 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Commit:4
   Snapshot Index:4 Term:1 ConfState:Voters:[2 3 4] VotersOutgoing:[1 2 3] Learners:[] LearnersNext:[] AutoLeave:false
   Messages:
@@ -267,7 +267,7 @@ stabilize
   2->4 MsgAppResp Term:2 Log:0/5
   3->4 MsgAppResp Term:2 Log:0/5
 > 4 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:2 Vote:4 Commit:5
   CommittedEntries:
   2/5 EntryNormal ""
@@ -282,21 +282,21 @@ stabilize
 > 3 receiving messages
   4->3 MsgApp Term:2 Log:2/5 Commit:5
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:2 Vote:4 Commit:5
   CommittedEntries:
   2/5 EntryNormal ""
   Messages:
   1->4 MsgAppResp Term:2 Log:0/5
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:2 Vote:4 Commit:5
   CommittedEntries:
   2/5 EntryNormal ""
   Messages:
   2->4 MsgAppResp Term:2 Log:0/5
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:2 Vote:4 Commit:5
   CommittedEntries:
   2/5 EntryNormal ""
@@ -360,7 +360,7 @@ stabilize
   2->4 MsgAppResp Term:2 Log:0/6
   3->4 MsgAppResp Term:2 Log:0/6
 > 4 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:2 Vote:4 Commit:6
   CommittedEntries:
   2/6 EntryConfChangeV2
@@ -376,7 +376,7 @@ stabilize
 > 3 receiving messages
   4->3 MsgApp Term:2 Log:2/6 Commit:6
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:2 Vote:4 Commit:6
   CommittedEntries:
   2/6 EntryConfChangeV2
@@ -384,7 +384,7 @@ stabilize
   1->4 MsgAppResp Term:2 Log:0/6
   INFO 1 switched to configuration voters=(2 3 4)
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:2 Vote:4 Commit:6
   CommittedEntries:
   2/6 EntryConfChangeV2
@@ -392,7 +392,7 @@ stabilize
   2->4 MsgAppResp Term:2 Log:0/6
   INFO 2 switched to configuration voters=(2 3 4)
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:2 Vote:4 Commit:6
   CommittedEntries:
   2/6 EntryConfChangeV2

--- a/testdata/confchange_v2_replace_leader_stepdown.txt
+++ b/testdata/confchange_v2_replace_leader_stepdown.txt
@@ -111,7 +111,7 @@ stabilize
   3->1 MsgAppResp Term:1 Log:0/5
   4->1 MsgAppResp Term:1 Log:0/5
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:5
   CommittedEntries:
   1/5 EntryConfChangeV2
@@ -131,7 +131,7 @@ stabilize
   Ready MustSync=false:
   Lead:0 State:StateFollower
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:5
   CommittedEntries:
   1/5 EntryConfChangeV2
@@ -139,7 +139,7 @@ stabilize
   2->1 MsgAppResp Term:1 Log:0/5
   INFO 2 switched to configuration voters=(2 3 4)
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:5
   CommittedEntries:
   1/5 EntryConfChangeV2
@@ -147,7 +147,7 @@ stabilize
   3->1 MsgAppResp Term:1 Log:0/5
   INFO 3 switched to configuration voters=(2 3 4)
 > 4 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Commit:5
   CommittedEntries:
   1/5 EntryConfChangeV2

--- a/testdata/lagging_commit.txt
+++ b/testdata/lagging_commit.txt
@@ -77,7 +77,7 @@ stabilize 1 2
   2->1 MsgAppResp Term:1 Log:0/12
   2->1 MsgAppResp Term:1 Log:0/13
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:13
   CommittedEntries:
   1/12 EntryNormal "data1"
@@ -91,7 +91,7 @@ stabilize 1 2
   1->2 MsgApp Term:1 Log:1/13 Commit:12
   1->2 MsgApp Term:1 Log:1/13 Commit:13
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:13
   CommittedEntries:
   1/12 EntryNormal "data1"
@@ -163,7 +163,7 @@ stabilize 1 3
 > 3 receiving messages
   1->3 MsgApp Term:1 Log:1/13 Commit:13
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:13
   CommittedEntries:
   1/12 EntryNormal "data1"

--- a/testdata/prevote.txt
+++ b/testdata/prevote.txt
@@ -85,7 +85,7 @@ INFO 2 [logterm: 1, index: 12, vote: 1] rejected MsgPreVote from 3 [logterm: 1, 
 stabilize
 ----
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:12
   CommittedEntries:
   1/12 EntryNormal "prop_1"
@@ -106,7 +106,7 @@ stabilize
   1->3 MsgPreVoteResp Term:1 Log:0/0 Rejected (Hint: 0)
   2->3 MsgPreVoteResp Term:1 Log:0/0 Rejected (Hint: 0)
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:12
   CommittedEntries:
   1/12 EntryNormal "prop_1"
@@ -235,7 +235,7 @@ stabilize
   1->2 MsgAppResp Term:2 Log:0/13
   3->2 MsgAppResp Term:2 Log:0/13
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:2 Vote:2 Commit:13
   CommittedEntries:
   2/13 EntryNormal ""
@@ -247,14 +247,14 @@ stabilize
 > 3 receiving messages
   2->3 MsgApp Term:2 Log:2/13 Commit:13
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:2 Vote:2 Commit:13
   CommittedEntries:
   2/13 EntryNormal ""
   Messages:
   1->2 MsgAppResp Term:2 Log:0/13
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:2 Vote:2 Commit:13
   CommittedEntries:
   2/13 EntryNormal ""

--- a/testdata/prevote_checkquorum.txt
+++ b/testdata/prevote_checkquorum.txt
@@ -159,7 +159,7 @@ stabilize
   1->3 MsgAppResp Term:2 Log:0/12
   2->3 MsgAppResp Term:2 Log:0/12
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:2 Vote:3 Commit:12
   CommittedEntries:
   2/12 EntryNormal ""
@@ -171,14 +171,14 @@ stabilize
 > 2 receiving messages
   3->2 MsgApp Term:2 Log:2/12 Commit:12
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:2 Commit:12
   CommittedEntries:
   2/12 EntryNormal ""
   Messages:
   1->3 MsgAppResp Term:2 Log:0/12
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:2 Vote:3 Commit:12
   CommittedEntries:
   2/12 EntryNormal ""
@@ -315,7 +315,7 @@ stabilize
   1->2 MsgAppResp Term:3 Log:0/13
   3->2 MsgAppResp Term:3 Log:0/13
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:3 Vote:2 Commit:13
   CommittedEntries:
   3/13 EntryNormal ""
@@ -327,14 +327,14 @@ stabilize
 > 3 receiving messages
   2->3 MsgApp Term:3 Log:3/13 Commit:13
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:3 Vote:2 Commit:13
   CommittedEntries:
   3/13 EntryNormal ""
   Messages:
   1->2 MsgAppResp Term:3 Log:0/13
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:3 Commit:13
   CommittedEntries:
   3/13 EntryNormal ""

--- a/testdata/probe_and_replicate.txt
+++ b/testdata/probe_and_replicate.txt
@@ -584,7 +584,7 @@ stabilize 1 4
 > 1 receiving messages
   4->1 MsgAppResp Term:8 Log:0/21
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:8 Vote:1 Commit:21
   CommittedEntries:
   6/19 EntryNormal "prop_6_19"
@@ -597,7 +597,7 @@ stabilize 1 4
 > 4 receiving messages
   1->4 MsgApp Term:8 Log:8/21 Commit:21
 > 4 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:8 Commit:21
   CommittedEntries:
   6/19 EntryNormal "prop_6_19"

--- a/testdata/single_node.txt
+++ b/testdata/single_node.txt
@@ -28,7 +28,7 @@ stabilize
   Entries:
   1/4 EntryNormal ""
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:4
   CommittedEntries:
   1/4 EntryNormal ""

--- a/testdata/snapshot_succeed_via_app_resp.txt
+++ b/testdata/snapshot_succeed_via_app_resp.txt
@@ -114,7 +114,7 @@ stabilize 3
   INFO 3 [commit: 11, lastindex: 11, lastterm: 1] restored snapshot [index: 11, term: 1]
   INFO 3 [commit: 11] restored snapshot [index: 11, term: 1]
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Commit:11
   Snapshot Index:11 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
   Messages:

--- a/testdata/snapshot_succeed_via_app_resp_behind.txt
+++ b/testdata/snapshot_succeed_via_app_resp_behind.txt
@@ -142,7 +142,7 @@ dropped: 1->3 MsgSnap Term:1 Log:0/0
 stabilize 3
 ----
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:11
   Snapshot Index:11 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
   Messages:


### PR DESCRIPTION
Even when are only applying committed entries (not appending WAL entries), the users also need to sync the `HardState` to disk as long as its value (including `Commit`) differs from previous value. Otherwise the users may run into a situation that the ApplyIndex > CommitIndex.

In example below, the last entry (a learner promotion operation) was actually committed, and also applied by etcd. But the HardState wasn't synced to disk (because `MustSync` returned false), so the commitIndex was still 9 instead of the correct value 10. Note that etcd reads the commitIndex from WAL file (from `HardState`),
```
$ ./etcd-dump-logs /tmp/etcd-etcd-1
Snapshot:
empty
Start dumping log entries from snapshot.
WAL metadata:
nodeID=b71f75320dc06a6c clusterID=1c45a069f3a1d796 term=2 commitIndex=9 vote=b71f75320dc06a6c
WAL entries: 10
lastIndex=10
term	     index	type	data
   1	         1	conf	method=ConfChangeAddNode id=b71f75320dc06a6c
   2	         2	norm	
   2	         3	norm	method=PUT path="/0/members/b71f75320dc06a6c/attributes" val="{\"name\":\"etcd-1\",\"clientURLs\":[\"http://127.0.0.1:2379\"]}"
   2	         4	norm	method=PUT path="/0/version" val="3.5.0"
   2	         5	conf	method=ConfChangeAddLearnerNode id=1bf18b91d6691abf
   2	         6	norm	method=PUT path="/0/members/1bf18b91d6691abf/attributes" val="{\"name\":\"etcd-2\",\"clientURLs\":[\"http://127.0.0.1:2378\"]}"
   2	         7	conf	method=ConfChangeAddNode id=1bf18b91d6691abf
   2	         8	conf	method=ConfChangeAddLearnerNode id=4b7ef604fa9ef7e1
   2	         9	norm	method=PUT path="/0/members/4b7ef604fa9ef7e1/attributes" val="{\"name\":\"etcd-3\",\"clientURLs\":[\"http://127.0.0.1:2377\"]}"
   2	        10	conf	method=ConfChangeAddNode id=4b7ef604fa9ef7e1

Entry types (Normal,ConfigChange) count is : 10
```

The applyIndex (consistent_index in etcd) was actualy already 10, it means that the index 10 has already been applied by etcd,

```
$ ./etcd-dump-db iterate-bucket /tmp/etcd-etcd-1/member/snap/db meta --decode
key="term", value=2
key="consistent_index", value=10
key="confState", value="{\"voters\":[2013543966895053503,5440055901155162081,13195394291058371180],\"auto_leave\":false}"
```

In etcd, we also have a use case that users can forcibly recreate a one-member cluster based on the data, no matter how many members the previous cluster has. In that cases, etcd will discard all uncommitted entries in this case and automatically remove all other members. Since previously the last HardState wasn't synced to disk, it causes the last actually committed entries being discarded (overwritten). 

When we forcibly recreated a one-member cluster,

```
$ etcd --name etcd-1 --data-dir /tmp/etcd-etcd-1 --force-new-cluster
```

etcd tried to automatically remove other members (commit two confChanges directly in a previous 3 member cluster, see index 10 and 11). Obviously previous entry with index 10 was overwritten.

```
$ ./etcd-dump-logs /tmp/etcd-etcd-1
Snapshot:
empty
Start dumping log entries from snapshot.
WAL metadata:
nodeID=b71f75320dc06a6c clusterID=1c45a069f3a1d796 term=3 commitIndex=13 vote=b71f75320dc06a6c
WAL entries: 13
lastIndex=13
term	     index	type	data
   1	         1	conf	method=ConfChangeAddNode id=b71f75320dc06a6c
   2	         2	norm	
   2	         3	norm	method=PUT path="/0/members/b71f75320dc06a6c/attributes" val="{\"name\":\"etcd-1\",\"clientURLs\":[\"http://127.0.0.1:2379\"]}"
   2	         4	norm	method=PUT path="/0/version" val="3.5.0"
   2	         5	conf	method=ConfChangeAddLearnerNode id=1bf18b91d6691abf
   2	         6	norm	method=PUT path="/0/members/1bf18b91d6691abf/attributes" val="{\"name\":\"etcd-2\",\"clientURLs\":[\"http://127.0.0.1:2378\"]}"
   2	         7	conf	method=ConfChangeAddNode id=1bf18b91d6691abf
   2	         8	conf	method=ConfChangeAddLearnerNode id=4b7ef604fa9ef7e1
   2	         9	norm	method=PUT path="/0/members/4b7ef604fa9ef7e1/attributes" val="{\"name\":\"etcd-3\",\"clientURLs\":[\"http://127.0.0.1:2377\"]}"
   2	        10	conf	method=ConfChangeRemoveNode id=1bf18b91d6691abf
   2	        11	conf	method=ConfChangeRemoveNode id=4b7ef604fa9ef7e1
   3	        12	norm	
   3	        13	norm	method=PUT path="/0/members/b71f75320dc06a6c/attributes" val="{\"name\":\"etcd-1\",\"clientURLs\":[\"http://localhost:2379\"]}"

Entry types (Normal,ConfigChange) count is : 13
```

The Index 10 has already been applied, so etcd won't re-apply it, so eventually one of the members were not removed at all,

```
$ ./etcd-dump-db iterate-bucket /tmp/etcd-etcd-1/member/snap/db members --decode
key="b71f75320dc06a6c", value="{\"id\":13195394291058371180,\"peerURLs\":[\"http://127.0.0.1:2380\"],\"name\":\"etcd-1\",\"clientURLs\":[\"http://localhost:2379\"]}"
key="1bf18b91d6691abf", value="{\"id\":2013543966895053503,\"peerURLs\":[\"http://127.0.0.1:2382\"],\"name\":\"etcd-2\",\"clientURLs\":[\"http://127.0.0.1:2378\"]}"

$ ./etcd-dump-db iterate-bucket /tmp/etcd-etcd-1/member/snap/db members_removed --decode
key="4b7ef604fa9ef7e1", value="removed"
```

@pav-kv @erikgrinaker @tbg @joshuazh-x