### PR TITLE
chore: use Go usetesting

### DIFF
--- a/node_bench_test.go
+++ b/node_bench_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func BenchmarkOneNode(b *testing.B) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(b.Context())
 	defer cancel()
 
 	s := newTestMemoryStorage(withPeers(1))

--- a/rafttest/node_bench_test.go
+++ b/rafttest/node_bench_test.go
@@ -15,7 +15,6 @@
 package rafttest
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -37,7 +36,7 @@ func BenchmarkProposal3Nodes(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		nodes[0].Propose(context.TODO(), []byte("somedata"))
+		nodes[0].Propose(b.Context(), []byte("somedata"))
 	}
 
 	for _, n := range nodes {

--- a/rafttest/node_test.go
+++ b/rafttest/node_test.go
@@ -15,7 +15,6 @@
 package rafttest
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -38,7 +37,7 @@ func TestBasicProgress(t *testing.T) {
 	waitLeader(nodes)
 
 	for i := 0; i < 100; i++ {
-		nodes[0].Propose(context.TODO(), []byte("somedata"))
+		nodes[0].Propose(t.Context(), []byte("somedata"))
 	}
 
 	assert.True(t, waitCommitConverge(nodes, 100))
@@ -63,19 +62,19 @@ func TestRestart(t *testing.T) {
 	k1, k2 := (l+1)%5, (l+2)%5
 
 	for i := 0; i < 30; i++ {
-		nodes[l].Propose(context.TODO(), []byte("somedata"))
+		nodes[l].Propose(t.Context(), []byte("somedata"))
 	}
 	nodes[k1].stop()
 	for i := 0; i < 30; i++ {
-		nodes[(l+3)%5].Propose(context.TODO(), []byte("somedata"))
+		nodes[(l+3)%5].Propose(t.Context(), []byte("somedata"))
 	}
 	nodes[k2].stop()
 	for i := 0; i < 30; i++ {
-		nodes[(l+4)%5].Propose(context.TODO(), []byte("somedata"))
+		nodes[(l+4)%5].Propose(t.Context(), []byte("somedata"))
 	}
 	nodes[k2].restart()
 	for i := 0; i < 30; i++ {
-		nodes[l].Propose(context.TODO(), []byte("somedata"))
+		nodes[l].Propose(t.Context(), []byte("somedata"))
 	}
 	nodes[k1].restart()
 
@@ -100,19 +99,19 @@ func TestPause(t *testing.T) {
 	waitLeader(nodes)
 
 	for i := 0; i < 30; i++ {
-		nodes[0].Propose(context.TODO(), []byte("somedata"))
+		nodes[0].Propose(t.Context(), []byte("somedata"))
 	}
 	nodes[1].pause()
 	for i := 0; i < 30; i++ {
-		nodes[0].Propose(context.TODO(), []byte("somedata"))
+		nodes[0].Propose(t.Context(), []byte("somedata"))
 	}
 	nodes[2].pause()
 	for i := 0; i < 30; i++ {
-		nodes[0].Propose(context.TODO(), []byte("somedata"))
+		nodes[0].Propose(t.Context(), []byte("somedata"))
 	}
 	nodes[2].resume()
 	for i := 0; i < 30; i++ {
-		nodes[0].Propose(context.TODO(), []byte("somedata"))
+		nodes[0].Propose(t.Context(), []byte("somedata"))
 	}
 	nodes[1].resume()
 


### PR DESCRIPTION
This PR adds GO `usetesting`, to  be aligned with [etcd](https://github.com/etcd-io/etcd) repo. 

The directive itself will be added in a follow-up PR, not to fail the CI workflow.

cc @ahrtr @ivanvc  