### PR TITLE
chore: add  linter directive

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -27,6 +27,7 @@ linters:
     - stylecheck
     - unused
     - unconvert # Remove unnecessary type conversions
+    - usetesting
 
 linters-settings: # please keep this alphabetized
   goimports:


### PR DESCRIPTION
This PR enables `usetesting` linter directive.

Follow up of https://github.com/etcd-io/raft/pull/302 

cc  @ahrtr  @ivanvc 