### PR TITLE
chore(CI): add gci formatter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -2,7 +2,15 @@ run:
   timeout: 30m
   skip-files:
     - "^zz_generated.*"
-
+formatters:
+  enable:
+    - gci
+  settings: # please keep this alphabetized
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(go.etcd.io)
 issues:
   max-same-issues: 0
   # Excluding configuration per-path, per-linter, per-text and per-source

--- a/tools/mod/tools.go
+++ b/tools/mod/tools.go
@@ -32,10 +32,11 @@ import (
 	_ "github.com/mdempsky/unconvert"
 	_ "github.com/mgechev/revive"
 	_ "github.com/mikefarah/yq/v4"
-	_ "go.etcd.io/gofail"
-	_ "go.etcd.io/protodoc"
 	_ "gotest.tools/gotestsum"
 	_ "gotest.tools/v3"
 	_ "honnef.co/go/tools/cmd/staticcheck"
 	_ "mvdan.cc/unparam"
+
+	_ "go.etcd.io/gofail"
+	_ "go.etcd.io/protodoc"
 )


### PR DESCRIPTION
This PR add `gci` import formatter to this repo.

See https://github.com/etcd-io/bbolt/pull/988#discussion_r2148704895

cc @ahrtr @ivanvc

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.