### PR TITLE
raft: return error when ConfChange is rejected due to pending change

### DIFF
--- a/testdata/confchange_v2_add_single_explicit.txt
+++ b/testdata/confchange_v2_add_single_explicit.txt
@@ -103,6 +103,7 @@ propose-conf-change 1
 v3 v4 v5
 ----
 INFO 1 ignoring conf change {ConfChangeTransitionAuto [{ConfChangeAddNode 3} {ConfChangeAddNode 4} {ConfChangeAddNode 5}] []} at config voters=(1 2)&&(1): must transition out of joint config first
+raft proposal dropped
 
 # Propose a transition out of the joint config. We'll see this at index 6 below.
 propose-conf-change 1
@@ -165,6 +166,7 @@ stabilize
 propose-conf-change 1
 ----
 INFO 1 ignoring conf change {ConfChangeTransitionAuto [] []} at config voters=(1 2): not in joint state; refusing empty conf change
+raft proposal dropped
 
 # Finishes work for the empty entry we just proposed.
 stabilize


### PR DESCRIPTION
Previously, when a ConfChange proposal was rejected (e.g., due to an existing pending config change), the proposal was silently converted to a no-op entry without returning any error. This silent failure could lead to security issues where administrators believe a configuration change succeeded when it was actually ignored.

This commit adds error notification while preserving the original behavior of appending a no-op entry for log consistency:

1. When a ConfChange is rejected, it is still converted to a no-op (maintaining backward compatibility and log consistency)
2. BUT now returns ErrProposalDropped to notify the caller

This allows callers to:
- Detect when their ConfChange was rejected
- Take appropriate action (e.g., wait and retry)
- Log warnings or alerts

The fix is conservative: it maintains full backward compatibility with existing log structures while adding explicit error notification.

https://github.com/etcd-io/raft/issues/354