### PR TITLE
tla: fix division by zero in StepToNextTrace action

### DIFF
--- a/tla/Traceetcdraft.tla
+++ b/tla/Traceetcdraft.tla
@@ -113,7 +113,7 @@ TraceInit ==
 StepToNextTrace == 
     /\ l' = l+1
     /\ pl' = l
-    /\ l % (Len(TraceLog) \div 100) = 0 => PrintT(<< "Progress %:", (l * 100) \div Len(TraceLog)>>)
+    /\ l % Max({1, Len(TraceLog) \div 100}) = 0 => PrintT(<< "Progress %:", (l * 100) \div Len(TraceLog)>>)
     /\ l' > Len(TraceLog) => PrintT(<< "Progress %:", 100>>)
     
 StepToNextTraceIfMessageIsProcessed(msg) ==


### PR DESCRIPTION
 https://github.com/etcd-io/raft/blob/bf04fb163bb3d58580b94eca1b97b061aae7a10b/tla/Traceetcdraft.tla#L113-L117

  ## Problem
  When the trace length is less than 100, the expression `Len(TraceLog) \div 100` evaluates to 0 in the [`StepToNextTrace`](https://github.com/etcd-io/raft/blob/bf04fb163bb3d58580b94eca1b97b061aae7a10b/tla/Traceetcdraft.tla#L113-L117) function. This causes a division by zero error in the modulo operation at line 116, which immediately aborts TLC model checking and causes `validate.sh` to report false negatives.

  ## Solution
  Replace `Len(TraceLog) \div 100` with `Max({1, Len(TraceLog) \div 100})` to ensure the divisor is at least 1. This maintains the progress printing functionality for both short and long traces:
  - For traces < 100: prints progress every step
  - For traces >= 100: prints progress every 1%