### PR TITLE
Allow users to pass in a snapshot with only the ConfState initialized during bootstrap

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -211,7 +211,10 @@ func (ms *MemoryStorage) ApplySnapshot(snap pb.Snapshot) error {
 	//handle check for old snapshot being applied
 	msIndex := ms.snapshot.Metadata.Index
 	snapIndex := snap.Metadata.Index
-	if msIndex >= snapIndex {
+	// During bootstrap, applications (e.g., etcd) may initialize only the
+	// ConfState in the snapshot. In this case, both the snapshot index and
+	// term are 0.
+	if msIndex != 0 && msIndex >= snapIndex {
 		return ErrSnapOutOfDate
 	}
 


### PR DESCRIPTION
Link to https://github.com/etcd-io/etcd/pull/21138 and https://github.com/etcd-io/etcd/issues/20187

During etcd bootstrap, it will initialize raft's conf state using etcd v3store, in that case both the existing snapshot's index and the passed snapshot may have index 0. However there is a restriction in current implementation, the passed snapshot must have a bigger index than existing one. This PR relaxes this restriction.