### PR TITLE
Security: Potential nil pointer dereference in interaction_env_handler_forget_leader.go

### DIFF
--- a/rafttest/interaction_env_handler_campaign.go
+++ b/rafttest/interaction_env_handler_campaign.go
@@ -15,6 +15,7 @@
 package rafttest
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/cockroachdb/datadriven"
@@ -27,5 +28,8 @@ func (env *InteractionEnv) handleCampaign(t *testing.T, d datadriven.TestData) e
 
 // Campaign the node at the given index.
 func (env *InteractionEnv) Campaign(idx int) error {
+	if idx < 0 || idx >= len(env.Nodes) {
+		return fmt.Errorf("node index %d out of range [0, %d)", idx, len(env.Nodes))
+	}
 	return env.Nodes[idx].Campaign()
 }

--- a/rafttest/interaction_env_handler_forget_leader.go
+++ b/rafttest/interaction_env_handler_forget_leader.go
@@ -15,6 +15,7 @@
 package rafttest
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/cockroachdb/datadriven"
@@ -22,11 +23,14 @@ import (
 
 func (env *InteractionEnv) handleForgetLeader(t *testing.T, d datadriven.TestData) error {
 	idx := firstAsNodeIdx(t, d)
-	env.ForgetLeader(idx)
-	return nil
+	return env.ForgetLeader(idx)
 }
 
 // ForgetLeader makes the follower at the given index forget its leader.
-func (env *InteractionEnv) ForgetLeader(idx int) {
+func (env *InteractionEnv) ForgetLeader(idx int) error {
+	if idx < 0 || idx >= len(env.Nodes) {
+		return fmt.Errorf("node index %d out of range [0, %d)", idx, len(env.Nodes))
+	}
 	env.Nodes[idx].ForgetLeader()
+	return nil
 }


### PR DESCRIPTION
## Summary

Security: Potential nil pointer dereference in interaction_env_handler_forget_leader.go

## Problem

**Severity**: `Medium` | **File**: `rafttest/interaction_env_handler_forget_leader.go:L36`

The `ForgetLeader` method calls `env.Nodes[idx].ForgetLeader()` without bounds checking on `idx`. While `firstAsNodeIdx` is used in the handler, the public `ForgetLeader` method can be called directly with an invalid index, causing a panic.

## Solution

Add bounds checking to the `ForgetLeader` method to ensure `idx` is within valid range before accessing `env.Nodes[idx]`.

## Changes

- `rafttest/interaction_env_handler_forget_leader.go` (modified)
- `rafttest/interaction_env_handler_campaign.go` (modified)