### PR TITLE
bump go 1.26.4 for tools go.mod

### DIFF
--- a/tools/mod/go.mod
+++ b/tools/mod/go.mod
@@ -2,7 +2,7 @@ module go.etcd.io/raft/tools/v3
 
 go 1.26
 
-toolchain go1.26.3
+toolchain go1.26.4
 
 require (
 	github.com/alexkohler/nakedret v1.0.0


### PR DESCRIPTION
Follow-up to #444.

I missed updating `tools/go.mod` in the original Go version bump. This PR updates it to keep the Go version consistent across the repository.
