### PR TITLE
refactor: replace interface{} with any (Go 1.18+)

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -23,23 +23,23 @@ import (
 )
 
 type Logger interface {
-	Debug(v ...interface{})
-	Debugf(format string, v ...interface{})
+	Debug(v ...any)
+	Debugf(format string, v ...any)
 
-	Error(v ...interface{})
-	Errorf(format string, v ...interface{})
+	Error(v ...any)
+	Errorf(format string, v ...any)
 
-	Info(v ...interface{})
-	Infof(format string, v ...interface{})
+	Info(v ...any)
+	Infof(format string, v ...any)
 
-	Warning(v ...interface{})
-	Warningf(format string, v ...interface{})
+	Warning(v ...any)
+	Warningf(format string, v ...any)
 
-	Fatal(v ...interface{})
-	Fatalf(format string, v ...interface{})
+	Fatal(v ...any)
+	Fatalf(format string, v ...any)
 
-	Panic(v ...interface{})
-	Panicf(format string, v ...interface{})
+	Panic(v ...any)
+	Panicf(format string, v ...any)
 }
 
 func SetLogger(l Logger) {
@@ -83,57 +83,57 @@ func (l *DefaultLogger) EnableDebug() {
 	l.debug = true
 }
 
-func (l *DefaultLogger) Debug(v ...interface{}) {
+func (l *DefaultLogger) Debug(v ...any) {
 	if l.debug {
 		l.Output(calldepth, header("DEBUG", fmt.Sprint(v...)))
 	}
 }
 
-func (l *DefaultLogger) Debugf(format string, v ...interface{}) {
+func (l *DefaultLogger) Debugf(format string, v ...any) {
 	if l.debug {
 		l.Output(calldepth, header("DEBUG", fmt.Sprintf(format, v...)))
 	}
 }
 
-func (l *DefaultLogger) Info(v ...interface{}) {
+func (l *DefaultLogger) Info(v ...any) {
 	l.Output(calldepth, header("INFO", fmt.Sprint(v...)))
 }
 
-func (l *DefaultLogger) Infof(format string, v ...interface{}) {
+func (l *DefaultLogger) Infof(format string, v ...any) {
 	l.Output(calldepth, header("INFO", fmt.Sprintf(format, v...)))
 }
 
-func (l *DefaultLogger) Error(v ...interface{}) {
+func (l *DefaultLogger) Error(v ...any) {
 	l.Output(calldepth, header("ERROR", fmt.Sprint(v...)))
 }
 
-func (l *DefaultLogger) Errorf(format string, v ...interface{}) {
+func (l *DefaultLogger) Errorf(format string, v ...any) {
 	l.Output(calldepth, header("ERROR", fmt.Sprintf(format, v...)))
 }
 
-func (l *DefaultLogger) Warning(v ...interface{}) {
+func (l *DefaultLogger) Warning(v ...any) {
 	l.Output(calldepth, header("WARN", fmt.Sprint(v...)))
 }
 
-func (l *DefaultLogger) Warningf(format string, v ...interface{}) {
+func (l *DefaultLogger) Warningf(format string, v ...any) {
 	l.Output(calldepth, header("WARN", fmt.Sprintf(format, v...)))
 }
 
-func (l *DefaultLogger) Fatal(v ...interface{}) {
+func (l *DefaultLogger) Fatal(v ...any) {
 	l.Output(calldepth, header("FATAL", fmt.Sprint(v...)))
 	os.Exit(1)
 }
 
-func (l *DefaultLogger) Fatalf(format string, v ...interface{}) {
+func (l *DefaultLogger) Fatalf(format string, v ...any) {
 	l.Output(calldepth, header("FATAL", fmt.Sprintf(format, v...)))
 	os.Exit(1)
 }
 
-func (l *DefaultLogger) Panic(v ...interface{}) {
+func (l *DefaultLogger) Panic(v ...any) {
 	l.Logger.Panic(v...)
 }
 
-func (l *DefaultLogger) Panicf(format string, v ...interface{}) {
+func (l *DefaultLogger) Panicf(format string, v ...any) {
 	l.Logger.Panicf(format, v...)
 }
 

--- a/node_util_test.go
+++ b/node_util_test.go
@@ -26,54 +26,54 @@ type nodeTestHarness struct {
 	t *testing.T
 }
 
-func (l *nodeTestHarness) Debug(v ...interface{}) {
+func (l *nodeTestHarness) Debug(v ...any) {
 	l.t.Log(v...)
 }
 
-func (l *nodeTestHarness) Debugf(format string, v ...interface{}) {
+func (l *nodeTestHarness) Debugf(format string, v ...any) {
 	l.t.Logf(format, v...)
 }
 
-func (l *nodeTestHarness) Error(v ...interface{}) {
+func (l *nodeTestHarness) Error(v ...any) {
 	l.t.Error(v...)
 }
 
-func (l *nodeTestHarness) Errorf(format string, v ...interface{}) {
+func (l *nodeTestHarness) Errorf(format string, v ...any) {
 	l.t.Errorf(format, v...)
 }
 
-func (l *nodeTestHarness) Info(v ...interface{}) {
+func (l *nodeTestHarness) Info(v ...any) {
 	l.t.Log(v...)
 }
 
-func (l *nodeTestHarness) Infof(format string, v ...interface{}) {
+func (l *nodeTestHarness) Infof(format string, v ...any) {
 	l.t.Logf(format, v...)
 }
 
-func (l *nodeTestHarness) Warning(v ...interface{}) {
+func (l *nodeTestHarness) Warning(v ...any) {
 	l.t.Log(v...)
 }
 
-func (l *nodeTestHarness) Warningf(format string, v ...interface{}) {
+func (l *nodeTestHarness) Warningf(format string, v ...any) {
 	l.t.Logf(format, v...)
 }
 
-func (l *nodeTestHarness) Fatal(v ...interface{}) {
+func (l *nodeTestHarness) Fatal(v ...any) {
 	l.t.Error(v...)
 	panic(fmt.Sprint(v...))
 }
 
-func (l *nodeTestHarness) Fatalf(format string, v ...interface{}) {
+func (l *nodeTestHarness) Fatalf(format string, v ...any) {
 	l.t.Errorf(format, v...)
 	panic(fmt.Sprintf(format, v...))
 }
 
-func (l *nodeTestHarness) Panic(v ...interface{}) {
+func (l *nodeTestHarness) Panic(v ...any) {
 	l.t.Log(v...)
 	panic(fmt.Sprint(v...))
 }
 
-func (l *nodeTestHarness) Panicf(format string, v ...interface{}) {
+func (l *nodeTestHarness) Panicf(format string, v ...any) {
 	l.t.Errorf(format, v...)
 	panic(fmt.Sprintf(format, v...))
 }

--- a/raft_test.go
+++ b/raft_test.go
@@ -34,7 +34,7 @@ import (
 // comparing field values via proto.Equal to avoid false failures from internal
 // protobuf metadata fields (e.g. atomicMessageInfo) that differ between
 // entries created as struct literals and those returned by proto operations.
-func requireEqualEntries(t testing.TB, expected, actual []*pb.Entry, msgAndArgs ...interface{}) {
+func requireEqualEntries(t testing.TB, expected, actual []*pb.Entry, msgAndArgs ...any) {
 	t.Helper()
 	require.Len(t, actual, len(expected), msgAndArgs...)
 	for i := range expected {
@@ -45,7 +45,7 @@ func requireEqualEntries(t testing.TB, expected, actual []*pb.Entry, msgAndArgs 
 // assertEqualMessages asserts that two message slices are semantically equal,
 // using proto.Equal to avoid false failures from atomicMessageInfo in embedded
 // entry fields.
-func assertEqualMessages(t testing.TB, expected, actual []*pb.Message, msgAndArgs ...interface{}) {
+func assertEqualMessages(t testing.TB, expected, actual []*pb.Message, msgAndArgs ...any) {
 	t.Helper()
 	assert.Len(t, actual, len(expected), msgAndArgs...)
 	n := len(expected)

--- a/rafttest/interaction_env_logger.go
+++ b/rafttest/interaction_env_logger.go
@@ -32,7 +32,7 @@ type RedirectLogger struct {
 
 var _ raft.Logger = (*RedirectLogger)(nil)
 
-func (l *RedirectLogger) printf(lvl int, format string, args ...interface{}) {
+func (l *RedirectLogger) printf(lvl int, format string, args ...any) {
 	if l.Lvl <= lvl {
 		fmt.Fprint(l, lvlNames[lvl], " ")
 		fmt.Fprintf(l, format, args...)
@@ -41,61 +41,61 @@ func (l *RedirectLogger) printf(lvl int, format string, args ...interface{}) {
 		}
 	}
 }
-func (l *RedirectLogger) print(lvl int, args ...interface{}) {
+func (l *RedirectLogger) print(lvl int, args ...any) {
 	if l.Lvl <= lvl {
 		fmt.Fprint(l, lvlNames[lvl], " ")
 		fmt.Fprintln(l, args...)
 	}
 }
 
-func (l *RedirectLogger) Debug(v ...interface{}) {
+func (l *RedirectLogger) Debug(v ...any) {
 	l.print(0, v...)
 }
 
-func (l *RedirectLogger) Debugf(format string, v ...interface{}) {
+func (l *RedirectLogger) Debugf(format string, v ...any) {
 	l.printf(0, format, v...)
 }
 
-func (l *RedirectLogger) Info(v ...interface{}) {
+func (l *RedirectLogger) Info(v ...any) {
 	l.print(1, v...)
 }
 
-func (l *RedirectLogger) Infof(format string, v ...interface{}) {
+func (l *RedirectLogger) Infof(format string, v ...any) {
 	l.printf(1, format, v...)
 }
 
-func (l *RedirectLogger) Warning(v ...interface{}) {
+func (l *RedirectLogger) Warning(v ...any) {
 	l.print(2, v...)
 }
 
-func (l *RedirectLogger) Warningf(format string, v ...interface{}) {
+func (l *RedirectLogger) Warningf(format string, v ...any) {
 	l.printf(2, format, v...)
 }
 
-func (l *RedirectLogger) Error(v ...interface{}) {
+func (l *RedirectLogger) Error(v ...any) {
 	l.print(3, v...)
 }
 
-func (l *RedirectLogger) Errorf(format string, v ...interface{}) {
+func (l *RedirectLogger) Errorf(format string, v ...any) {
 	l.printf(3, format, v...)
 }
 
-func (l *RedirectLogger) Fatal(v ...interface{}) {
+func (l *RedirectLogger) Fatal(v ...any) {
 	l.print(4, v...)
 	panic(fmt.Sprint(v...))
 }
 
-func (l *RedirectLogger) Fatalf(format string, v ...interface{}) {
+func (l *RedirectLogger) Fatalf(format string, v ...any) {
 	l.printf(4, format, v...)
 	panic(fmt.Sprintf(format, v...))
 }
 
-func (l *RedirectLogger) Panic(v ...interface{}) {
+func (l *RedirectLogger) Panic(v ...any) {
 	l.print(4, v...)
 	panic(fmt.Sprint(v...))
 }
 
-func (l *RedirectLogger) Panicf(format string, v ...interface{}) {
+func (l *RedirectLogger) Panicf(format string, v ...any) {
 	l.printf(4, format, v...)
 	// TODO(pavelkalinnikov): catch the panic gracefully in datadriven package.
 	// This would allow observing all the intermediate logging while debugging,

--- a/state_trace_nop.go
+++ b/state_trace_nop.go
@@ -23,7 +23,7 @@ import (
 
 const StateTraceDeployed = false
 
-type TraceLogger interface{}
+type TraceLogger any
 
 type TracingEvent struct{}
 


### PR DESCRIPTION
Replace `interface{}` with `any` (available since Go 1.18) across 5 files:
- logger.go
- state_trace_nop.go
- raft_test.go
- node_util_test.go
- rafttest/interaction_env_logger.go

This project already requires Go 1.26 (see go.mod).