### PR TITLE
raft: reduce async storage missing entry log noise

### DIFF
--- a/log_unstable.go
+++ b/log_unstable.go
@@ -139,7 +139,7 @@ func (u *unstable) stableTo(id entryID) {
 	gt, ok := u.maybeTerm(id.index)
 	if !ok {
 		// Unstable entry missing. Ignore.
-		u.logger.Infof("entry at index %d missing from unstable log; ignoring", id.index)
+		u.logger.Debugf("entry at index %d missing from unstable log; ignoring", id.index)
 		return
 	}
 	if id.index < u.offset {

--- a/testdata/async_storage_writes.txt
+++ b/testdata/async_storage_writes.txt
@@ -791,10 +791,10 @@ deliver-msgs 1 2 3
 3->1 MsgAppResp Term:1 Log:0/15
 ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/14 EntryNormal "prop_3"]
 AppendThread->2 MsgStorageAppendResp Term:1 Log:1/15
-INFO entry at index 15 missing from unstable log; ignoring
+DEBUG entry at index 15 missing from unstable log; ignoring
 ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/14 EntryNormal "prop_3"]
 AppendThread->3 MsgStorageAppendResp Term:1 Log:1/15
-INFO entry at index 15 missing from unstable log; ignoring
+DEBUG entry at index 15 missing from unstable log; ignoring
 ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/14 EntryNormal "prop_3"]
 
 process-ready 1 2 3
@@ -866,4 +866,4 @@ stabilize
   Responses:
 > 1 receiving messages
   AppendThread->1 MsgStorageAppendResp Term:1 Log:1/15
-  INFO entry at index 15 missing from unstable log; ignoring
+  DEBUG entry at index 15 missing from unstable log; ignoring


### PR DESCRIPTION
## Summary

Downgrade the log message

`entry at index %d missing from unstable log; ignoring`

from info level to debug level.

## Motivation

With async storage writes enabled, this condition can occur during normal processing and generates noisy info-level logs. Since the condition is expected and non-actionable in this mode, debug level is more appropriate.

## Testing

* Updated async storage trace expectations.
* Ran `go test ./...`.
* All tests passed.

Fixes #307.
