### PR TITLE
raft: fix TLA+ specification to match unapplied config guard

### DIFF
--- a/tla/etcdraft.tla
+++ b/tla/etcdraft.tla
@@ -221,6 +221,17 @@ GetLearners(i) ==
 ApplyConfigUpdate(i, k) ==
     [config EXCEPT ![i]= [jointConfig |-> << log[i][k].value.newconf, {} >>, learners |-> log[i][k].value.learners]]
 
+ConfigOfEntry(e) ==
+    [jointConfig |-> << e.value.newconf, {} >>, learners |-> e.value.learners]
+
+LatestCommittedConfigIndex(i) ==
+    SelectLastInSubSeq(log[i], 1, commitIndex[i], LAMBDA x: x.type = ConfigEntry)
+
+HasUnappliedCommittedConfig(i) ==
+    LET k == LatestCommittedConfigIndex(i)
+    IN /\ k > 0
+       /\ config[i] # ConfigOfEntry(log[i][k])
+
 CommitTo(i, c) ==
     commitIndex' = [commitIndex EXCEPT ![i] = Max({@, c})]
 
@@ -291,6 +302,7 @@ Restart(i) ==
 \* @type: Int => Bool;
 Timeout(i) == /\ state[i] \in {Follower, Candidate}
               /\ i \in GetConfig(i)
+              /\ ~HasUnappliedCommittedConfig(i)
               /\ state' = [state EXCEPT ![i] = Candidate]
               /\ currentTerm' = [currentTerm EXCEPT ![i] = currentTerm[i] + 1]
               /\ votedFor' = [votedFor EXCEPT ![i] = i]


### PR DESCRIPTION
As described in issue #456, the current TLA+ model of this Raft implementation is subtly broken due to a missing guard condition for leader campaigns. In the actual implementation, a follower or pre-candidate needs to check that there are no unapplied committed reconfig entries in its local log before initiating a campaign, but this check is not enforced in the model, leading to a potential safety violation. This PR fixes the issue by adding the guard condition. Running the driver spec in #456 against the updated TLA+ model shows that the safety violation is avoided.