### PR TITLE
tla: block campaigns with unapplied config changes

### DIFF
--- a/tla/MCetcdraft.tla
+++ b/tla/MCetcdraft.tla
@@ -44,6 +44,8 @@ etcdInitLogVars     == /\ log          = [i \in Server |-> IF i \in InitServer T
                        /\ commitIndex  = [i \in Server |-> IF i \in InitServer THEN Cardinality(InitServer) ELSE 0]
 etcdInitConfigVars  == /\ config = [i \in Server |-> [ jointConfig |-> IF i \in InitServer THEN <<InitServer, {}>> ELSE <<{}, {}>>, learners |-> {}]]
                        /\ reconfigCount = 0 \* the bootstrap configuraitons are not counted
+                       \* the bootstrap config entries are already applied
+                       /\ appliedConfChangeIndex = [i \in Server |-> IF i \in InitServer THEN Cardinality(InitServer) ELSE 0]
 
 \* This file controls the constants as seen below.
 \* In addition to basic settings of how many nodes are to be model checked,

--- a/tla/README.md
+++ b/tla/README.md
@@ -72,6 +72,15 @@ The TLA+ spec defines the desired behaviors of the model. To validate the correc
 ./validate-model.sh -s ./MCetcdraft.tla -c ./MCetcdraft.cfg 
 ```
 
+## Regression Scenarios
+Some safety bugs of the spec were found via counterexamples that are too deep for exhaustive model checking to reach in reasonable time. Such counterexamples are kept as scripted scenario specs that replay one exact schedule against `etcdraft.tla` and check the safety invariants along it. They finish in seconds and act as regression tests for the spec:
+
+```console
+./validate-model.sh -s ./SplitBrain456.tla -c ./SplitBrain456.cfg
+```
+
+* `SplitBrain456.tla` replays the split-brain schedule from [issue #456](https://github.com/etcd-io/raft/issues/456): two servers campaign with active configurations that lag differently far behind the committed configuration entries in their logs. It checks `MoreThanOneLeaderInv` and asserts that the last campaign is blocked by the `HasUnappliedConfChange` guard in `Timeout`.
+
 
 ## Validate Collected Traces
 With above example trace logger, validate.sh can be used to validate traces parallelly.

--- a/tla/README.md
+++ b/tla/README.md
@@ -73,14 +73,11 @@ The TLA+ spec defines the desired behaviors of the model. To validate the correc
 ```
 
 ## Regression Scenarios
-Some safety bugs of the spec were found via counterexamples that are too deep for exhaustive model checking to reach in reasonable time. Such counterexamples are kept as scripted scenario specs that replay one exact schedule against `etcdraft.tla` and check the safety invariants along it. They finish in seconds and act as regression tests for the spec:
+Some spec bugs can require schedules that are too deep or too specific for bounded model checking to find quickly. For those cases, a scripted scenario spec can replay the known schedule against etcdraft.tla and check the same safety invariants. This gives us a fast regression test for the bug without relying on TLC to rediscover the full counterexample.
 
-```console
 ./validate-model.sh -s ./SplitBrain456.tla -c ./SplitBrain456.cfg
-```
 
-* `SplitBrain456.tla` replays the split-brain schedule from [issue #456](https://github.com/etcd-io/raft/issues/456): two servers campaign with active configurations that lag differently far behind the committed configuration entries in their logs. It checks `MoreThanOneLeaderInv` and asserts that the last campaign is blocked by the `HasUnappliedConfChange` guard in `Timeout`.
-
+SplitBrain456.tla replays the split-brain schedule from issue #456. Two servers campaign with active configurations that lag differently behind the committed configuration entries in their logs. The scenario checks MoreThanOneLeaderInv and asserts that the final campaign is blocked by the HasUnappliedConfChange guard in Timeout.
 
 ## Validate Collected Traces
 With above example trace logger, validate.sh can be used to validate traces parallelly.

--- a/tla/SplitBrain456.cfg
+++ b/tla/SplitBrain456.cfg
@@ -1,0 +1,36 @@
+\* Copyright 2026 The etcd Authors
+\*
+\* Licensed under the Apache License, Version 2.0 (the "License");
+\* you may not use this file except in compliance with the License.
+\* You may obtain a copy of the License at
+\*
+\*     http://www.apache.org/licenses/LICENSE-2.0
+\*
+\* Unless required by applicable law or agreed to in writing, software
+\* distributed under the License is distributed on an "AS IS" BASIS,
+\* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+\* See the License for the specific language governing permissions and
+\* limitations under the License.
+\*
+CONSTANTS
+    Nil = 0
+    Follower = "Follower"
+    Candidate = "Candidate"
+    Leader = "Leader"
+    RequestVoteRequest = "RequestVoteRequest"
+    RequestVoteResponse = "RequestVoteResponse"
+    AppendEntriesRequest = "AppendEntriesRequest"
+    AppendEntriesResponse = "AppendEntriesResponse"
+    ValueEntry = "ValueEntry"
+    ConfigEntry = "ConfigEntry"
+    Server = {1, 2, 3, 4, 5}
+    InitServer = {1, 2, 3}
+
+SPECIFICATION DriverSpec
+
+CHECK_DEADLOCK
+    FALSE
+
+INVARIANT MoreThanOneLeaderInv
+
+PROPERTY CampaignBlockedByGuard

--- a/tla/SplitBrain456.tla
+++ b/tla/SplitBrain456.tla
@@ -1,0 +1,355 @@
+---------------------------- MODULE SplitBrain456 ----------------------------
+\* Copyright 2026 The etcd Authors
+\*
+\* Licensed under the Apache License, Version 2.0 (the "License");
+\* you may not use this file except in compliance with the License.
+\* You may obtain a copy of the License at
+\*
+\*     http://www.apache.org/licenses/LICENSE-2.0
+\*
+\* Unless required by applicable law or agreed to in writing, software
+\* distributed under the License is distributed on an "AS IS" BASIS,
+\* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+\* See the License for the specific language governing permissions and
+\* limitations under the License.
+\*
+\* Regression scenario for https://github.com/etcd-io/raft/issues/456
+\* (scenario script adapted from the BugDriver spec attached to the issue).
+\*
+\* It scripts the following schedule against etcdraft.tla:
+\*   1. s1 becomes leader of {s1,s2,s3} in term 1.
+\*   2. s1 commits config change #1: {s1,s2,s3}      -> {s1,s2,s3,s4}.
+\*   3. s1 commits config change #2: {s1,s2,s3,s4}   -> {s1,s2,s3,s4,s5}.
+\*   4. s2 learns both entries are committed and applies config #2;
+\*      s3 has both entries in its log but learned only entry #1 is
+\*      committed and applied neither.
+\*   5. s2 campaigns and wins term 2 with votes {s2,s4,s5} under config
+\*      {s1,s2,s3,s4,s5}.
+\*   6. s3 attempts to campaign under its stale active config {s1,s2,s3}.
+\*
+\* Without the HasUnappliedConfChange guard on Timeout, step 6 elects s3
+\* with votes {s1,s3} in the same term 2 - two leaders in one term
+\* (MoreThanOneLeaderInv is violated). With the guard, s3 must not campaign
+\* while config change #1 is committed but unapplied, and the scenario
+\* stops right before step 6, which is asserted by CampaignBlockedByGuard.
+\*
+\* Run:
+\*   java -cp tla2tools.jar:CommunityModules-deps.jar tlc2.TLC \
+\*     -config SplitBrain456.cfg SplitBrain456.tla
+EXTENDS etcdraft
+
+VARIABLE pc
+
+DriverVars == <<vars, pc>>
+
+\* Message-selection helpers used by the scripted schedule below.
+RecvRVReq(dst, src) ==
+    \E m \in DOMAIN messages :
+        /\ m.mtype = RequestVoteRequest
+        /\ m.msource = src
+        /\ m.mdest = dst
+        /\ Receive(m)
+
+RecvRVResp(dst, src) ==
+    \E m \in DOMAIN messages :
+        /\ m.mtype = RequestVoteResponse
+        /\ m.msource = src
+        /\ m.mdest = dst
+        /\ Receive(m)
+
+RecvAEReq(dst, src, subtype) ==
+    \E m \in DOMAIN messages :
+        /\ m.mtype = AppendEntriesRequest
+        /\ m.msubtype = subtype
+        /\ m.msource = src
+        /\ m.mdest = dst
+        /\ Receive(m)
+
+RecvAEReqAck(dst, src, subtype) ==
+    \E m \in DOMAIN messages :
+        /\ m.mtype = AppendEntriesRequest
+        /\ m.msubtype = subtype
+        /\ m.msource = src
+        /\ m.mdest = dst
+        /\ Receive(m)
+        /\ m \notin DOMAIN messages'
+
+RecvAEResp(dst, src, subtype) ==
+    \E m \in DOMAIN messages :
+        /\ m.mtype = AppendEntriesResponse
+        /\ m.msubtype = subtype
+        /\ m.msource = src
+        /\ m.mdest = dst
+        /\ Receive(m)
+
+DriverInit == Init /\ pc = 0
+
+DriverNext ==
+    \/ \* Elect server 1 as leader in term 1 with votes from 1 and 2.
+       /\ pc = 0
+       /\ Timeout(1)
+       /\ pc' = 1
+    \/ /\ pc = 1
+       /\ RequestVote(1, 1)
+       /\ pc' = 2
+    \/ /\ pc = 2
+       /\ Ready(1)
+       /\ pc' = 3
+    \/ /\ pc = 3
+       /\ RecvRVResp(1, 1)
+       /\ pc' = 4
+    \/ /\ pc = 4
+       /\ RequestVote(1, 2)
+       /\ pc' = 5
+    \/ /\ pc = 5
+       /\ Ready(1)
+       /\ pc' = 6
+    \/ /\ pc = 6
+       /\ RecvRVReq(2, 1) \* server 2 first updates to term 1
+       /\ pc' = 7
+    \/ /\ pc = 7
+       /\ RecvRVReq(2, 1) \* server 2 grants the vote
+       /\ pc' = 8
+    \/ /\ pc = 8
+       /\ Ready(2)
+       /\ pc' = 9
+    \/ /\ pc = 9
+       /\ RecvRVResp(1, 2)
+       /\ pc' = 10
+    \/ /\ pc = 10
+       /\ BecomeLeader(1)
+       /\ pc' = 11
+
+    \/ \* Append and commit the first configuration entry: {1,2,3} -> {1,2,3,4}.
+       /\ pc = 11
+       /\ AddNewServer(1, 4)
+       /\ pc' = 12
+    \/ /\ pc = 12
+       /\ AppendEntriesToSelf(1)
+       /\ pc' = 13
+    \/ /\ pc = 13
+       /\ Ready(1)
+       /\ pc' = 14
+    \/ /\ pc = 14
+       /\ RecvAEResp(1, 1, "app")
+       /\ pc' = 15
+    \/ /\ pc = 15
+       /\ AppendEntries(1, 2, <<1, 2>>)
+       /\ pc' = 16
+    \/ /\ pc = 16
+       /\ Ready(1)
+       /\ pc' = 17
+    \/ /\ pc = 17
+       /\ RecvAEReq(2, 1, "app") \* append entry 1 on server 2
+       /\ pc' = 18
+    \/ /\ pc = 18
+       /\ RecvAEReqAck(2, 1, "app") \* acknowledge entry 1 from server 2
+       /\ pc' = 19
+    \/ /\ pc = 19
+       /\ Ready(2)
+       /\ pc' = 20
+    \/ /\ pc = 20
+       /\ RecvAEResp(1, 2, "app")
+       /\ pc' = 21
+    \/ /\ pc = 21
+       /\ AppendEntries(1, 3, <<1, 2>>)
+       /\ pc' = 22
+    \/ /\ pc = 22
+       /\ Ready(1)
+       /\ pc' = 23
+    \/ /\ pc = 23
+       /\ RecvAEReq(3, 1, "app") \* server 3 first updates to term 1
+       /\ pc' = 24
+    \/ /\ pc = 24
+       /\ RecvAEReq(3, 1, "app") \* append entry 1 on server 3
+       /\ pc' = 25
+    \/ /\ pc = 25
+       /\ RecvAEReqAck(3, 1, "app") \* acknowledge entry 1 from server 3
+       /\ pc' = 26
+    \/ /\ pc = 26
+       /\ Ready(3)
+       /\ pc' = 27
+    \/ /\ pc = 27
+       /\ RecvAEResp(1, 3, "app")
+       /\ pc' = 28
+    \/ /\ pc = 28
+       /\ AdvanceCommitIndex(1)
+       /\ pc' = 29
+    \/ /\ pc = 29
+       /\ ApplySimpleConfChange(1) \* only the leader applies entry 1
+       /\ pc' = 30
+
+    \/ \* Append and commit the second configuration entry: {1,2,3,4} -> {1,2,3,4,5}.
+       /\ pc = 30
+       /\ AddNewServer(1, 5)
+       /\ pc' = 31
+    \/ /\ pc = 31
+       /\ AppendEntriesToSelf(1)
+       /\ pc' = 32
+    \/ /\ pc = 32
+       /\ Ready(1)
+       /\ pc' = 33
+    \/ /\ pc = 33
+       /\ RecvAEResp(1, 1, "app")
+       /\ pc' = 34
+    \/ /\ pc = 34
+       /\ AppendEntries(1, 2, <<2, 3>>)
+       /\ pc' = 35
+    \/ /\ pc = 35
+       /\ Ready(1)
+       /\ pc' = 36
+    \/ /\ pc = 36
+       /\ RecvAEReq(2, 1, "app") \* append entry 2 on server 2
+       /\ pc' = 37
+    \/ /\ pc = 37
+       /\ RecvAEReqAck(2, 1, "app") \* acknowledge entry 2 from server 2
+       /\ pc' = 38
+    \/ /\ pc = 38
+       /\ Ready(2)
+       /\ pc' = 39
+    \/ /\ pc = 39
+       /\ RecvAEResp(1, 2, "app")
+       /\ pc' = 40
+    \/ /\ pc = 40
+       /\ AppendEntries(1, 3, <<2, 3>>)
+       /\ pc' = 41
+    \/ /\ pc = 41
+       /\ Ready(1)
+       /\ pc' = 42
+    \/ /\ pc = 42
+       /\ RecvAEReq(3, 1, "app") \* append entry 2 on server 3
+       /\ pc' = 43
+    \/ /\ pc = 43
+       /\ RecvAEReqAck(3, 1, "app") \* acknowledge entry 2 from server 3
+       /\ pc' = 44
+    \/ /\ pc = 44
+       /\ Ready(3)
+       /\ pc' = 45
+    \/ /\ pc = 45
+       /\ RecvAEResp(1, 3, "app")
+       /\ pc' = 46
+    \/ /\ pc = 46
+       /\ AdvanceCommitIndex(1)
+       /\ pc' = 47
+    \/ /\ pc = 47
+       /\ Heartbeat(1, 2) \* tell server 2 that entry 2 is committed
+       /\ pc' = 48
+    \/ /\ pc = 48
+       /\ Ready(1)
+       /\ pc' = 49
+    \/ /\ pc = 49
+       /\ RecvAEReq(2, 1, "heartbeat")
+       /\ pc' = 50
+    \/ /\ pc = 50
+       /\ Ready(2)
+       /\ pc' = 51
+    \/ /\ pc = 51
+       /\ RecvAEResp(1, 2, "heartbeat")
+       /\ pc' = 52
+    \/ /\ pc = 52
+       /\ ApplySimpleConfChange(2) \* server 2 applies entry 2; server 3 applies neither entry
+       /\ pc' = 53
+
+    \/ \* Server 2 campaigns using applied config {1,2,3,4,5} and wins with {2,4,5}.
+       /\ pc = 53
+       /\ Timeout(2)
+       /\ pc' = 54
+    \/ /\ pc = 54
+       /\ RequestVote(2, 2)
+       /\ pc' = 55
+    \/ /\ pc = 55
+       /\ Ready(2)
+       /\ pc' = 56
+    \/ /\ pc = 56
+       /\ RecvRVResp(2, 2)
+       /\ pc' = 57
+    \/ /\ pc = 57
+       /\ RequestVote(2, 4)
+       /\ pc' = 58
+    \/ /\ pc = 58
+       /\ Ready(2)
+       /\ pc' = 59
+    \/ /\ pc = 59
+       /\ RecvRVReq(4, 2) \* server 4 first updates to term 2
+       /\ pc' = 60
+    \/ /\ pc = 60
+       /\ RecvRVReq(4, 2) \* server 4 grants the vote
+       /\ pc' = 61
+    \/ /\ pc = 61
+       /\ Ready(4)
+       /\ pc' = 62
+    \/ /\ pc = 62
+       /\ RecvRVResp(2, 4)
+       /\ pc' = 63
+    \/ /\ pc = 63
+       /\ RequestVote(2, 5)
+       /\ pc' = 64
+    \/ /\ pc = 64
+       /\ Ready(2)
+       /\ pc' = 65
+    \/ /\ pc = 65
+       /\ RecvRVReq(5, 2) \* server 5 first updates to term 2
+       /\ pc' = 66
+    \/ /\ pc = 66
+       /\ RecvRVReq(5, 2) \* server 5 grants the vote
+       /\ pc' = 67
+    \/ /\ pc = 67
+       /\ Ready(5)
+       /\ pc' = 68
+    \/ /\ pc = 68
+       /\ RecvRVResp(2, 5)
+       /\ pc' = 69
+    \/ /\ pc = 69
+       /\ BecomeLeader(2)
+       /\ pc' = 70
+
+    \/ \* Server 3 attempts to campaign in the same term using its stale
+       \* active config {1,2,3}. This must be blocked: server 3 still has
+       \* the committed-but-unapplied config entries 1 and 2 in its log.
+       \* If Timeout(3) were allowed here, server 3 would win with votes
+       \* {1,3} under config {1,2,3} while server 2 is already leader of
+       \* term 2 under config {1,2,3,4,5} - a split brain.
+       /\ pc = 70
+       /\ Timeout(3)
+       /\ pc' = 71
+    \/ /\ pc = 71
+       /\ RequestVote(3, 3)
+       /\ pc' = 72
+    \/ /\ pc = 72
+       /\ Ready(3)
+       /\ pc' = 73
+    \/ /\ pc = 73
+       /\ RecvRVResp(3, 3)
+       /\ pc' = 74
+    \/ /\ pc = 74
+       /\ RequestVote(3, 1)
+       /\ pc' = 75
+    \/ /\ pc = 75
+       /\ Ready(3)
+       /\ pc' = 76
+    \/ /\ pc = 76
+       /\ RecvRVReq(1, 3) \* server 1 first updates to term 2
+       /\ pc' = 77
+    \/ /\ pc = 77
+       /\ RecvRVReq(1, 3) \* server 1 grants the vote
+       /\ pc' = 78
+    \/ /\ pc = 78
+       /\ Ready(1)
+       /\ pc' = 79
+    \/ /\ pc = 79
+       /\ RecvRVResp(3, 1)
+       /\ pc' = 80
+    \/ /\ pc = 80
+       /\ BecomeLeader(3)
+       /\ pc' = 81
+
+DriverSpec == DriverInit /\ [][DriverNext]_DriverVars /\ WF_DriverVars(DriverNext)
+
+\* Sanity check that the schedule is not vacuously safe: every step up to
+\* and including the election of server 2 (pc = 70) must remain enabled,
+\* and the run must stop exactly at server 3's blocked campaign. If an
+\* earlier step becomes disabled by an unrelated spec change, this property
+\* fails and the scenario needs to be updated.
+CampaignBlockedByGuard == <>[](pc = 70)
+
+===============================================================================

--- a/tla/Traceetcdraft.tla
+++ b/tla/Traceetcdraft.tla
@@ -81,9 +81,12 @@ TraceInitServerVars == /\ currentTerm = [i \in Server |-> LastBootstrapLog[i].ev
                        /\ votedFor = [i \in Server |-> LastBootstrapLog[i].event.state.vote]
 TraceInitLogVars    == /\ log          = [i \in Server |-> [j \in 1..LastBootstrapLog[i].event.log |-> [ term |-> 1, type |-> "ConfigEntry", value |-> [newconf |-> BootstrappedConfig(i), learners |-> {}]]]]
                        /\ commitIndex  = [i \in Server |-> LastBootstrapLog[i].event.state.commit]
-TraceInitConfigVars == 
+TraceInitConfigVars ==
     /\ config = [i \in Server |-> [ jointConfig |-> <<BootstrappedConfig(i), {}>>, learners |-> {}] ]
-    /\ reconfigCount = 0 
+    /\ reconfigCount = 0
+    \* the bootstrapped config is applied, i.e. no committed-but-unapplied
+    \* config change exists at the end of bootstrap
+    /\ appliedConfChangeIndex = [i \in Server |-> LastBootstrapLog[i].event.state.commit]
                         
 
 -------------------------------------------------------------------------------------

--- a/tla/etcdraft.tla
+++ b/tla/etcdraft.tla
@@ -132,10 +132,18 @@ leaderVars == <<matchIndex, pendingConfChangeIndex>>
 \* @type: Int -> [jointConfig: Seq(Set(int)), learners: Set(int)]
 VARIABLE 
     config
-VARIABLE 
+VARIABLE
     reconfigCount
 
-configVars == <<config, reconfigCount>>
+\* The index of the latest configuration change entry that server i has
+\* applied to its active configuration (0 if none). The active configuration
+\* config[i] may lag behind committed configuration change entries in the log;
+\* this variable tracks how far application has progressed.
+VARIABLE
+    \* @type: Int -> Int;
+    appliedConfChangeIndex
+
+configVars == <<config, reconfigCount, appliedConfChangeIndex>>
 
 VARIABLE 
     durableState
@@ -217,6 +225,15 @@ IsJointConfig(i) ==
 GetLearners(i) ==
     config[i].learners
 
+\* TRUE iff the log of server i contains a committed but not yet applied
+\* configuration change entry. Mirrors hasUnappliedConfChanges() in raft.go:
+\* a server must not campaign while such an entry exists, because the active
+\* configuration it would use to count votes could lag more than one version
+\* behind the committed configuration, breaking quorum overlap between
+\* concurrent candidates (see https://github.com/etcd-io/raft/issues/456).
+HasUnappliedConfChange(i) ==
+    SelectLastInSubSeq(log[i], 1, commitIndex[i], LAMBDA x: x.type = ConfigEntry) > appliedConfChangeIndex[i]
+
 \* Apply conf change log entry to configuration
 ApplyConfigUpdate(i, k) ==
     [config EXCEPT ![i]= [jointConfig |-> << log[i][k].value.newconf, {} >>, learners |-> log[i][k].value.learners]]
@@ -226,13 +243,14 @@ CommitTo(i, c) ==
 
 CurrentLeaders == {i \in Server : state[i] = Leader}
 
-PersistState(i) == 
+PersistState(i) ==
     durableState' = [durableState EXCEPT ![i] = [
         currentTerm |-> currentTerm[i],
         votedFor |-> votedFor[i],
         log |-> Len(log[i]),
         commitIndex |-> commitIndex[i],
-        config |-> config[i]
+        config |-> config[i],
+        appliedConfChangeIndex |-> appliedConfChangeIndex[i]
     ]]
 
 ----
@@ -249,14 +267,16 @@ InitLeaderVars == /\ matchIndex = [i \in Server |-> [j \in Server |-> 0]]
 InitLogVars == /\ log          = [i \in Server |-> <<>>]
                /\ commitIndex  = [i \in Server |-> 0]
 InitConfigVars == /\ config = [i \in Server |-> [ jointConfig |-> <<InitServer, {}>>, learners |-> {}]]
-                  /\ reconfigCount = 0 
-InitDurableState == 
+                  /\ reconfigCount = 0
+                  /\ appliedConfChangeIndex = [i \in Server |-> 0]
+InitDurableState ==
     durableState = [ i \in Server |-> [
         currentTerm |-> currentTerm[i],
         votedFor |-> votedFor[i],
         log |-> Len(log[i]),
         commitIndex |-> commitIndex[i],
-        config |-> config[i]
+        config |-> config[i],
+        appliedConfChangeIndex |-> appliedConfChangeIndex[i]
     ]]
 
 Init == /\ InitMessageVars
@@ -285,12 +305,16 @@ Restart(i) ==
     /\ votedFor' = [votedFor EXCEPT ![i] = durableState[i].votedFor]
     /\ log' = [log EXCEPT ![i] = SubSeq(@, 1, durableState[i].log)]
     /\ config' = [config EXCEPT ![i] = durableState[i].config]
+    /\ appliedConfChangeIndex' = [appliedConfChangeIndex EXCEPT ![i] = durableState[i].appliedConfChangeIndex]
     /\ UNCHANGED <<messages, durableState, reconfigCount>>
 
 \* Server i times out and starts a new election.
 \* @type: Int => Bool;
 Timeout(i) == /\ state[i] \in {Follower, Candidate}
               /\ i \in GetConfig(i)
+              \* etcd refuses to campaign while a committed but unapplied
+              \* config change exists in the log (hup() in raft.go).
+              /\ ~HasUnappliedConfChange(i)
               /\ state' = [state EXCEPT ![i] = Candidate]
               /\ currentTerm' = [currentTerm EXCEPT ![i] = currentTerm[i] + 1]
               /\ votedFor' = [votedFor EXCEPT ![i] = i]
@@ -468,7 +492,8 @@ ApplySimpleConfChange(i) ==
             /\ k > 0
             /\ k <= commitIndex[i]
             /\ config' = ApplyConfigUpdate(i, k)
-            /\ IF state[i] = Leader /\ pendingConfChangeIndex[i] >= k THEN 
+            /\ appliedConfChangeIndex' = [appliedConfChangeIndex EXCEPT ![i] = k]
+            /\ IF state[i] = Leader /\ pendingConfChangeIndex[i] >= k THEN
                 /\ reconfigCount' = reconfigCount + 1
                 /\ pendingConfChangeIndex' = [pendingConfChangeIndex EXCEPT ![i] = 0]
                ELSE UNCHANGED <<reconfigCount, pendingConfChangeIndex>>


### PR DESCRIPTION
Problem

The TLA+ spec currently allows a server to start a campaign even when its log contains committed but unapplied config change entries. The Go implementation does not allow this. In hup(), raft checks hasUnappliedConfChanges() and abandons the campaign if such entries exist.

This matters because a server counts votes using its active config, and that config only advances when config entries are applied. Without the guard, the spec can let a candidate use a config that is more than one version behind the committed config. That breaks the quorum overlap argument between concurrent candidates.

TLC confirms the issue. With reconfigs {1,2,3} -> +4 -> +5 committed, s2, which has applied both changes, can win term 2 with {2,4,5}. At the same time, s3, which has applied neither change, can also win term 2 with {1,3}. This violates MoreThanOneLeaderInv.

The full schedule is in #456. Credit to the reporter for the counterexample driver.

Fix

This change adds appliedConfChangeIndex[i] to track the latest config change entry each server has applied. It is part of configVars, advances in ApplySimpleConfChange, and is persisted and restored together with config.

Timeout(i) now checks ~HasUnappliedConfChange(i) before allowing a campaign, matching the behavior of hup() in the Go implementation.

The bootstrap initializers in MCetcdraft and Traceetcdraft also mark bootstrap config entries as already applied.

Regression test

tla/SplitBrain456.tla replays the schedule from #456. It runs in about 3 seconds with TLC.

The test checks MoreThanOneLeaderInv and also includes a temporal sanity property that confirms the schedule reaches the point where the final campaign is now blocked. That keeps the test from passing vacuously.

The scenario fails on the parent commit and passes with this change.

Verification

SplitBrain456 is red before this change and green after it, with 82 states before and 71 states after.

A bounded MCetcdraft run reports no violations. Full exhaustive checking does not reach the roughly depth 80 counterexample, which is why this bug was not found by model checking.

Trace validation of tla/example.ndjson against the updated spec passes. This means the new guard does not reject behavior produced by the real implementation.

Why this was missed

Trace validation checks that implementation traces are allowed by the spec. That catches cases where the spec is too restrictive.

This bug was the opposite: the implementation was more restrictive than the spec. As a result, implementation traces still validated successfully.